### PR TITLE
Fixed Issue #32 - change root disk size and parameterized of cpu and ram

### DIFF
--- a/ansible/roles/openshift-4-cluster/defaults/main.yml
+++ b/ansible/roles/openshift-4-cluster/defaults/main.yml
@@ -10,8 +10,21 @@ vn_public_domain: "h42.openshift.pub"
 
 listen_address: "{{ hostvars['localhost']['ansible_default_ipv4']['address'] }}"
 
-master_count: "3"
-compute_count: "3"
+master_count: 3
+master_vcpu: 4
+master_memory_size: 16384
+master_memory_unit: 'MiB'
+# qemu-img image size specified.
+#   You may use k, M, G, T, P or E suffixe
+master_root_disk_size: '120G'
+
+compute_count: 3
+compute_vcpu: 2
+compute_memory_size: 8192
+compute_memory_unit: 'MiB'
+# qemu-img image size specified.
+#   You may use k, M, G, T, P or E suffixe
+compute_root_disk_size: '120G'
 
 # Important: OpenShift version must match to RHEL CoreOS version!
 

--- a/ansible/roles/openshift-4-cluster/tasks/create-vm.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/create-vm.yml
@@ -3,7 +3,7 @@
 # # /var/lib/libvirt/images/rhcos42.qcow2
 # # /var/lib/libvirt/images/CentOS-7-x86_64-GenericCloud.qcow2
 - name: Create disk for {{ vm_instance_name }}
-  command: "qemu-img convert -O qcow2 -o size=10G {{ coreos_image_location }} /var/lib/libvirt/images/{{ vm_instance_name }}.qcow2"
+  command: "qemu-img create -f qcow2 -b {{ coreos_image_location }} /var/lib/libvirt/images/{{ vm_instance_name }}.qcow2 {{ vm_root_disk_size }}"
   args:
     creates: "/var/lib/libvirt/images/{{ vm_instance_name }}.qcow2"
 

--- a/ansible/roles/openshift-4-cluster/tasks/create.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/create.yml
@@ -42,6 +42,10 @@
     vm_network: "{{ cluster_name }}"
     vm_ignition_file: "{{ openshift_install_dir }}/bootstrap.ign"
     vm_mac_address: "52:54:00:{{ '%02x' % vn_subnet.split('.')[1]|int }}:{{ '%02x' % vn_subnet.split('.')[2]|int }}:{{ '%02x' % 2 }}"
+    vm_vcpu: 4
+    vm_memory_size: 16384
+    vm_memory_unit: 'MiB'
+    vm_root_disk_size: '120G'
 
 - name: Create master nodes
   include: create-vm.yml
@@ -50,6 +54,10 @@
     vm_network: "{{ cluster_name }}"
     vm_ignition_file: "{{ openshift_install_dir }}/master.ign"
     vm_mac_address: "52:54:00:{{ '%02x' % vn_subnet.split('.')[1]|int }}:{{ '%02x' % vn_subnet.split('.')[2]|int }}:{{ '%02x' % (10 + item|int) }}"
+    vm_vcpu: "{{ master_vcpu }}"
+    vm_memory_size: "{{ master_memory_size }}"
+    vm_memory_unit: "{{ master_memory_unit }}"
+    vm_root_disk_size: "{{ master_root_disk_size }}"
   with_sequence: start=0 end="{{ master_count|int - 1 }}" stride=1
 
 - name: Create compute node
@@ -59,6 +67,10 @@
     vm_network: "{{ cluster_name }}"
     vm_ignition_file: "{{ openshift_install_dir }}/worker.ign"
     vm_mac_address: "52:54:00:{{ '%02x' % vn_subnet.split('.')[1]|int }}:{{ '%02x' % vn_subnet.split('.')[2]|int }}:{{ '%02x' % (10 + master_count|int + item|int) }}"
+    vm_vcpu: "{{ compute_vcpu }}"
+    vm_memory_size: "{{ compute_memory_size }}"
+    vm_memory_unit: "{{ compute_memory_unit }}"
+    vm_root_disk_size: "{{ compute_root_disk_size }}"
   with_sequence: start=0 end="{{ compute_count|int - 1 }}" stride=1
 
 - name: Include post installation tasks

--- a/ansible/roles/openshift-4-cluster/templates/vm.xml.j2
+++ b/ansible/roles/openshift-4-cluster/templates/vm.xml.j2
@@ -7,9 +7,9 @@
       <kvirt:plan>{{ cluster_name }}</kvirt:plan>
     </kvirt:info>
   </metadata>
-  <memory unit='MiB'>16384</memory>
-  <currentMemory unit='MiB'>16384</currentMemory>
-  <vcpu>4</vcpu>
+  <memory unit='{{ vm_memory_unit }}'>{{ vm_memory_size }}</memory>
+  <currentMemory unit='{{ vm_memory_unit }}'>{{ vm_memory_size }}</currentMemory>
+  <vcpu>{{ vm_vcpu }}</vcpu>
   <os>
     <type arch="x86_64">hvm</type>
     <boot dev="hd"/>


### PR DESCRIPTION
Added several new options:
```
master_count: 3
master_vcpu: 4
master_memory_size: 16384
master_memory_unit: 'MiB'
# qemu-img image size specified.
#   You may use k, M, G, T, P or E suffixe
master_root_disk_size: '120G'

compute_count: 3
compute_vcpu: 2
compute_memory_size: 8192
compute_memory_unit: 'MiB'
# qemu-img image size specified.
#   You may use k, M, G, T, P or E suffixe
compute_root_disk_size: '120G'
```