### PR TITLE
Add master_count to install-config

### DIFF
--- a/ansible/roles/openshift-4-cluster/templates/install-config.yaml.j2
+++ b/ansible/roles/openshift-4-cluster/templates/install-config.yaml.j2
@@ -7,7 +7,7 @@ compute:
 controlPlane:
   name: master
   platform: {}
-  replicas: 3
+  replicas: {{ master_count }} 
 metadata:
   name: {{ cluster_name }}
 networking:


### PR DESCRIPTION
Master replica was hardcoded in the install-config.yml.j2. This way we can run a single master setup using the `master_count` variable.