### PR TITLE
Fixing issue #70 - Updating CoreOS v4.2 remote link

### DIFF
--- a/ansible/roles/openshift-4-cluster/defaults/main.yml
+++ b/ansible/roles/openshift-4-cluster/defaults/main.yml
@@ -37,7 +37,7 @@ openshift_location: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp"
 
 # reference to coreos qcow file
 coreos_version: 42.80.20191002.0
-coreos_download_url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/latest/rhcos-{{ coreos_version }}-qemu.qcow2"
+coreos_download_url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/4.2.0-rc.5/rhcos-{{ coreos_version }}-qemu.qcow2"
 coreos_image_location: /var/lib/libvirt/images/rhcos-{{ coreos_version }}.qcow2 
 
 


### PR DESCRIPTION
I've experienced some issues in installing the current version (4.2).

I discovered that the remote location on openshift.com changed (`ansible/roles/openshift-4-cluster/defaults/main.yml`):
```
-coreos_download_url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/latest/rhcos-{{ coreos_version }}-qemu.qcow2"
+coreos_download_url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/4.2.0-rc.5/rhcos-{{ coreos_version }}-qemu.qcow2"
```

The /latest remote subdir now has been bumped to 4.3 version and qemu version disappeared.

We should always point to the latest stable to avoid these issues.
