### PR TITLE
Add REGISTRY_COMPATIBILITY_SCHEMA1_ENABLED to air-gapped docs

### DIFF
--- a/docs/air-gapped.md
+++ b/docs/air-gapped.md
@@ -57,6 +57,7 @@ ExecStart=/usr/bin/podman run --name mirror-registry --net host \
   -e "REGISTRY_HTTP_ADDR=192.168.50.1:5000" \
   -e "REGISTRY_AUTH_HTPASSWD_REALM=registry-realm" \
   -e "REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd" \
+  -e "REGISTRY_COMPATIBILITY_SCHEMA1_ENABLED=TRUE" \
   -v /var/lib/libvirt/images/mirror-registry/certs:/certs:z \
   -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt \
   -e REGISTRY_HTTP_TLS_KEY=/certs/domain.key \

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,6 +1,12 @@
 # RELEASE NOTES
 
-24.3.2020
+## xx
+
+### Update air-gapped docs 
+
+Add `REGISTRY_COMPATIBILITY_SCHEMA1_ENABLED=true` to air-gapped registry. That solve some skopeo copy problemes.
+
+## 24.3.2020
 
 ### Support for disabling automatic Let's Encrypt certificates for apps and api
 


### PR DESCRIPTION
## Description

Add REGISTRY_COMPATIBILITY_SCHEMA1_ENABLED=true to air-gapped registry. That solve some skopeo copy problemes.

## Checklist/ToDo's

- [X] Added documentation?
- [x] Added release note entry? (  docs/release-notes.md )
- [X] Tested? 