### PR TITLE
Fix #101 by automating coreos crc

### DIFF
--- a/ansible/roles/openshift-4-cluster/defaults/main.yml
+++ b/ansible/roles/openshift-4-cluster/defaults/main.yml
@@ -29,7 +29,7 @@ compute_root_disk_size: '120G'
 # Important: OpenShift version must match to RHEL CoreOS version!
 
 # reference to OpenShift version
-openshift_version: 4.3.0
+openshift_version: 4.4.5
 openshift_install_command: "/opt/openshift-install-{{ openshift_version }}/openshift-install"
 # dev-pre:
 # https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview
@@ -40,14 +40,15 @@ openshift_client_version: "{{ openshift_version }}"
 openshift_location: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{openshift_client_version}}"
 
 # reference to coreos qcow file
-coreos_version: 4.3.0
-coreos_download_url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/{{ coreos_version.split('.')[:2]|join('.') }}/{{ coreos_version }}/rhcos-{{coreos_version}}-x86_64-qemu.qcow2.gz"
+coreos_version: 4.4.3
+coreos_download_url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/{{ coreos_version.split('.')[:2]|join('.') }}/{{ coreos_version }}/rhcos-{{coreos_version}}-x86_64-qemu.x86_64.qcow2.gz"
+coreos_csum_url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/{{ coreos_version.split('.')[:2]|join('.') }}/{{ coreos_version }}/sha256sum.txt"
 
-# How to get the checksum:
-#  ansible -m stat -a 'path=/var/lib/libvirt/images/rhcos-4.3.0.qcow2' localhost  | grep checksum
-coreos_checksum: "8cf621e0996881d759399c699d766f7a28ec000e"
-coreos_image_location: /var/lib/libvirt/images/rhcos-{{ coreos_version }}.qcow2
-
+# you can check available version numbers from here:
+# https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/
+coreos_path: /var/lib/libvirt/images
+coreos_file: "rhcos-{{ coreos_version }}.qcow2"
+coreos_image_location: "{{ coreos_path }}/{{ coreos_file }}"
 
 certificates_dir: "{{ playbook_dir }}/../certificate"
 certficate_fullchain: "{{ certificates_dir }}/{{ cluster_name }}.{{ public_domain }}/fullchain.crt"

--- a/ansible/roles/openshift-4-cluster/tasks/download-openshift-artifacts.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/download-openshift-artifacts.yml
@@ -4,7 +4,6 @@
   set_fact:
     tmp_openshift_install_download_url: "{{ openshift_location }}/openshift-install-linux-{{ openshift_version }}.tar.gz"
     tmp_openshift_client_download_url: "{{ openshift_location }}/openshift-client-linux-{{ openshift_version }}.tar.gz"
-    
 
 - name: Check download urls
   uri:
@@ -13,43 +12,60 @@
     status_code: 200
   with_items:
     - "{{ coreos_download_url }}"
+    - "{{ coreos_csum_url }}"
     - "{{ tmp_openshift_install_download_url }}"
     - "{{ tmp_openshift_client_download_url }}"
     - "{{ helm_cli_location }}"
 
-# Can not use get_url because: get_url do not support --compressed
-- name: Download CoreOS image
-  command:
-    "curl --compressed -J -L -o {{ coreos_image_location }} {{ coreos_download_url }}"
-  args:
-    creates: "{{ coreos_image_location }}"
-    warn: false
-
-- name: Check coreos image filetype
+- name: check if coreos image already downloaded and get checksum
   stat:
-    path: "{{ coreos_image_location }}"
-  register: coreos_image
+    checksum_algorithm: sha256
+    path: "{{ coreos_path }}/{{ coreos_file }}"
+  register: coreos_old_image
 
-- block:
-  - name: Rename image -> image.gzip
-    command: "mv {{ coreos_image_location }} {{ coreos_image_location }}.gz"
-  - name: Unzip
-    command: "gzip -d {{ coreos_image_location }}.gz"
-  when: coreos_image.stat.mimetype == "application/x-gzip"
+- name: verify existing coreos image is valid
+  lineinfile:
+    name: "{{ coreos_path }}/{{ coreos_file }}.sha256.txt"
+    line: "{{ coreos_old_image.stat.checksum }}  {{ coreos_file }}"
+    state: present
+  check_mode: true
+  register: csum_check
+  failed_when: (csum_check is changed) or (csum_check is failed)
+  ignore_errors: true
+  when: coreos_old_image.stat.exists
 
-- name: CoreOS image checksum check
-  stat:
-    path: "{{ coreos_image_location }}"
-  register: checksum_coreos_image
+- name: Download fresh coreos image if previous doesn't exist
+  block:
 
-- name: Compare checksum
-  fail:
-    msg: |
-      Please check coreos image, something looks wrong!
-      File {{ coreos_image_location }} (Checksum: {{ checksum_coreos_image.stat.checksum }})
-      The checksum should be {{ coreos_checksum }}
-      Download location: {{ coreos_download_url }}
-  when: checksum_coreos_image.stat.checksum != coreos_checksum
+    - name: download coreos
+      get_url:
+        url: "{{ coreos_download_url }}"
+        dest: "{{ coreos_path }}/{{ coreos_file }}.gz"
+        checksum: "sha256:{{ coreos_csum_url }}"
+      register: coreos_download
+
+    - name: unzip the coreos
+      command: "gunzip {{ coreos_path }}/{{ coreos_file }}.gz"
+      args:
+        chdir: "{{ coreos_path }}"
+        creates: "{{ coreos_path }}/{{ coreos_file }}"
+      register: unzip
+
+    - name: calculate checksum of the new coreos image
+      stat:
+        checksum_algorithm: sha256
+        path: "{{ coreos_path }}/{{ coreos_file }}"
+      register: coreos_csum
+
+    - name: store the checksum of the file
+      copy:
+        dest: "{{ coreos_path }}/{{ coreos_file }}.sha256.txt"
+        content: "{{ coreos_csum.stat.checksum }}  {{ coreos_file }}\n"
+
+  when: >
+    (not coreos_old_image.stat.exists) or
+    csum_check.changed or
+    csum_check.failed
 
 - name: Create OpenShift artifacts directory
   file:


### PR DESCRIPTION
## Description

This fixes issue #101 about needing manually generate and store CRC checksum for coreos image. The code checks if coreos is already downloaded. If so, it checks the CRC of the file. If file not found, or CRC error (file corrupted) it downloads the image, checks zipped CRC, unzips it and stores the new CRC. The last one being the automated step.

This way it's easier for any user to change the OCP and CoreOS versions, it's enough to change the version in cluster.yml.

While at it, I updated the OCP and CoreOS versions to latest available ATM 4.4.5 and 4.4.3. I tested this, works fine for first install, and also I generated CRC error, and tried with missing coreos file. All worked fine.

## Checklist/ToDo's

- [ ] Added documentation?
- [ ] Added release note entry? (  docs/release-notes.md )
- [x] Tested? 