### PR TITLE
Fix/binary permissions

### DIFF
--- a/ansible/roles/openshift-4-cluster/tasks/download-openshift-artifacts.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/download-openshift-artifacts.yml
@@ -81,6 +81,7 @@
     src: "{{ tmp_openshift_install_download_url }}"
     dest: "/opt/openshift-install-{{ openshift_version }}/"
     remote_src: yes
+    mode: u+rwx,g-rx,o-rx
     creates: "/opt/openshift-install-{{ openshift_version }}/openshift-install"
 
 - name: Download Openshift client
@@ -88,11 +89,13 @@
     src: "{{ tmp_openshift_client_download_url }}"
     dest: "/opt/openshift-client-{{ openshift_version }}/"
     remote_src: yes
+    mode: u+rwx,g-rx,o-rx
     creates: "/opt/openshift-client-{{ openshift_version }}/oc"
 
 - name: Download Helm client
   get_url:
     url: "{{ helm_cli_location }}"
+    mode: u+rwx,g-rx,o-rx
     dest: "/opt/openshift-client-{{ openshift_version }}/helm"
 
 - name: Create a symbolic link


### PR DESCRIPTION
## Description
When downloading the helm binary I noticed it does not have the executable flag. I added the `mode` for all binaries to make sure that these binaries are executable by the root user. 

## Checklist/ToDo's

- [X] Tested? 