### PR TITLE
fix(sudoer): fix sudoers in cluster-example.yml

### DIFF
--- a/cluster-example.yml
+++ b/cluster-example.yml
@@ -30,7 +30,7 @@ auth_redhatsso:
   client_secret: "xxxxxxx"
 
 cluster_role_bindings:
-  - cluster_role: sudoers
+  - cluster_role: sudoer
     name: login@redhat.com
   - cluster_role: cluster-admin
     name: admin


### PR DESCRIPTION
## Description
As per [Impersonating the system:admin user](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.4/html-single/authentication/index) the correct ClusterRole for impersonating `system:admin` is `sudoer`. Fixed the default provided in `cluster-example.yml`