### PR TITLE
add mode for ignition file

### DIFF
--- a/ansible/roles/openshift-4-cluster/tasks/create-vm.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/create-vm.yml
@@ -11,7 +11,8 @@
   copy:
     src: "{{ vm_ignition_file }}"
     dest: "/var/lib/libvirt/images/{{ vm_instance_name }}.ign"
-
+    mode: '0644'
+  
 # - name: Debug - create /tmp/{{ vm_instance_name }}.virt.xml
 #   template:
 #     src: "vm.xml.j2"


### PR DESCRIPTION
if not exist, following warning and error occurs (CentOS 8.2, ansible 2.9.12)
```
TASK [openshift-4-cluster : Copy ignition ocp4-bootstrap] 
[WARNING]: File '/var/lib/libvirt/images/ocp4-bootstrap.ign' created with default permissions '600'. The previous default was '666'. Specify 'mode' to avoid this warning.

TASK [openshift-4-cluster : Start VirtualMachine ocp4-bootstrap] 

An exception occurred during task execution. To see the full traceback, use -vvv. The error was: libvirt.libvirtError: internal error: qemu unexpectedly closed the monitor: 
 qemu-kvm: -fw_cfg name=opt/com.coreos/config,file=/var/lib/libvirt/images/ocp4-bootstrap.ign: can't load /var/lib/libvirt/images/ocp4-bootstrap.ign
 p=71011 u=root n=ansible | fatal: [localhost]: FAILED! => {"changed": false, "msg": "internal error: qemu unexpectedly closed the monitor: 
 qemu-kvm: -fw_cfg name=opt/com.coreos/config,file=/var/lib/libvirt/images/ocp4-bootstrap.ign: can't load /var/lib/libvirt/images/ocp4-bootstrap.ign"}
```

## Description


## Checklist/ToDo's

- [ ] Added documentation?
- [ ] Added release note entry? (  docs/release-notes.md )
- [x] Tested? 