### PR TITLE
Add support for add-on roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ Please configure in `cluster.yml` all necessary credentials:
 
 # Additional documentation
 
-* [How to install and manage more than one OpenShift Cluster with  hetzner-ocp4](docs/multi-cluster-guide.md)
+* [How to use add-ons (post_install_add_ons)](docs/add-ons.md)
+* [How to install and manage more than one OpenShift Cluster with hetzner-ocp4](docs/multi-cluster-guide.md)
 * [How to install an air-gapped cluster with hetzner-ocp4](docs/air-gapped.md)
 * [How to install an proxy cluster with hetzner-ocp4](docs/proxy.md)
 * [How to setup a container native virtualization lab (nested) with hetzner-ocp4](docs/cnv.md)

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -16,7 +16,8 @@ retry_files_enabled = False
 retry_files_save_path = ~/ansible-installer-retries
 nocows = True
 remote_user = root
-# roles_path = roles/
+roles_path = ~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:ansible/roles/:ansible/add-on-roles/
+
 gathering = smart
 # fact_caching = jsonfile
 # fact_caching_connection = $HOME/ansible/facts

--- a/ansible/add-on-roles/cluster-entitlement/README.md
+++ b/ansible/add-on-roles/cluster-entitlement/README.md
@@ -1,0 +1,12 @@
+# How to use hetzner-ocp4-add-on-cluster-entitlement
+
+Add to cluster-addons.yml
+```
+post_install_add_ons:
+  - name: cluster-entitlement
+    tasks_from: "post-install.yaml"
+
+# Optional if you want to use specific entitlement id
+entitlement_id: 7045354189760625103
+```
+

--- a/ansible/add-on-roles/cluster-entitlement/tasks/entitlement-from-rhel-node.yaml
+++ b/ansible/add-on-roles/cluster-entitlement/tasks/entitlement-from-rhel-node.yaml
@@ -1,0 +1,48 @@
+---
+
+- name: Find entitlement
+  find:
+    paths: /etc/pki/entitlement/
+    patterns: '*-key.pem'
+  register: files
+
+- name: "Check amount of entitlement"
+  fail:
+    msg: "To many entitlements, please specify one if the entitlement ids via entitlement_id: {{ files.files | map(attribute='path') | map('regex_replace','^/etc/pki/entitlement/([0-9]+)-key.pem$', '\\1') | join(', ')  }}"
+  when: entitlement_id is not defined and files.matched > 1
+
+# /etc/pki/entitlement/4988695409571740307-key.pem
+# - debug:
+#     msg: "{{ files.files[0].path | regex_replace('^/etc/pki/entitlement/([0-9]+)-key.pem$', '\\1') }}"
+
+- name: Set entitlement_id in case of entitlement_id is not defined and amount of entitlement is one
+  set_fact:
+    entitlement_id: "{{ files.files[0].path | regex_replace('^/etc/pki/entitlement/([0-9]+)-key.pem$', '\\1') }}"
+  when: entitlement_id is not defined and files.matched == 1
+
+- shell: "cat /etc/pki/entitlement/{{ entitlement_id }}-key.pem | base64 -w0"
+  register: register_entitlement_key_base64
+
+- shell: "cat /etc/pki/entitlement/{{ entitlement_id }}.pem | base64 -w0"
+  register: register_entitlement_base64
+
+- name: Apply entitle machineconfig
+  k8s:
+    state: present
+    kubeconfig: "{{ k8s_kubeconfig }}"
+    host: "{{ k8s_host }}"
+    ca_cert: "{{ k8s_ca_cert }}"
+    client_cert: "{{ k8s_client_cert }}"
+    client_key: "{{ k8s_client_key }}"
+    definition: "{{ lookup('template', 'templates/0003-cluster-wide-machineconfigs.yaml.j2') }}"
+  vars:
+    entitlement_key_base64: "{{ register_entitlement_key_base64.stdout }}"
+    entitlement_base64: "{{ register_entitlement_base64.stdout }}"
+    role: "{{ loop_role }}"
+  with_items:
+    - master
+    - worker
+  loop_control:
+    loop_var: loop_role
+
+

--- a/ansible/add-on-roles/cluster-entitlement/tasks/post-install.yaml
+++ b/ansible/add-on-roles/cluster-entitlement/tasks/post-install.yaml
@@ -1,0 +1,8 @@
+---
+- name: GPU Post install
+  debug:
+    msg: "Run cluster entitlement against {{ kubeconfig }}"
+
+- name: "Include entitlement-from-rhel-node.yaml"
+  include: "entitlement-from-rhel-node.yaml"
+  when: ansible_distribution  == "RedHat"

--- a/ansible/add-on-roles/cluster-entitlement/templates/0003-cluster-wide-machineconfigs.yaml.j2
+++ b/ansible/add-on-roles/cluster-entitlement/templates/0003-cluster-wide-machineconfigs.yaml.j2
@@ -1,0 +1,55 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+  labels:
+    machineconfiguration.openshift.io/role: {{ role }}
+  name: 50-{{ role }}-rhsm-conf
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyBSZWQgSGF0IFN1YnNjcmlwdGlvbiBNYW5hZ2VyIENvbmZpZ3VyYXRpb24gRmlsZToKCiMgVW5pZmllZCBFbnRpdGxlbWVudCBQbGF0Zm9ybSBDb25maWd1cmF0aW9uCltzZXJ2ZXJdCiMgU2VydmVyIGhvc3RuYW1lOgpob3N0bmFtZSA9IHN1YnNjcmlwdGlvbi5yaHNtLnJlZGhhdC5jb20KCiMgU2VydmVyIHByZWZpeDoKcHJlZml4ID0gL3N1YnNjcmlwdGlvbgoKIyBTZXJ2ZXIgcG9ydDoKcG9ydCA9IDQ0MwoKIyBTZXQgdG8gMSB0byBkaXNhYmxlIGNlcnRpZmljYXRlIHZhbGlkYXRpb246Cmluc2VjdXJlID0gMAoKIyBTZXQgdGhlIGRlcHRoIG9mIGNlcnRzIHdoaWNoIHNob3VsZCBiZSBjaGVja2VkCiMgd2hlbiB2YWxpZGF0aW5nIGEgY2VydGlmaWNhdGUKc3NsX3ZlcmlmeV9kZXB0aCA9IDMKCiMgYW4gaHR0cCBwcm94eSBzZXJ2ZXIgdG8gdXNlCnByb3h5X2hvc3RuYW1lID0KCiMgVGhlIHNjaGVtZSB0byB1c2UgZm9yIHRoZSBwcm94eSB3aGVuIHVwZGF0aW5nIHJlcG8gZGVmaW5pdGlvbnMsIGlmIG5lZWRlZAojIGUuZy4gaHR0cCBvciBodHRwcwpwcm94eV9zY2hlbWUgPSBodHRwCgojIHBvcnQgZm9yIGh0dHAgcHJveHkgc2VydmVyCnByb3h5X3BvcnQgPQoKIyB1c2VyIG5hbWUgZm9yIGF1dGhlbnRpY2F0aW5nIHRvIGFuIGh0dHAgcHJveHksIGlmIG5lZWRlZApwcm94eV91c2VyID0KCiMgcGFzc3dvcmQgZm9yIGJhc2ljIGh0dHAgcHJveHkgYXV0aCwgaWYgbmVlZGVkCnByb3h5X3Bhc3N3b3JkID0KCiMgaG9zdC9kb21haW4gc3VmZml4IGJsYWNrbGlzdCBmb3IgcHJveHksIGlmIG5lZWRlZApub19wcm94eSA9CgpbcmhzbV0KIyBDb250ZW50IGJhc2UgVVJMOgpiYXNldXJsID0gaHR0cHM6Ly9jZG4ucmVkaGF0LmNvbQoKIyBSZXBvc2l0b3J5IG1ldGFkYXRhIEdQRyBrZXkgVVJMOgpyZXBvbWRfZ3BnX3VybCA9CgojIFNlcnZlciBDQSBjZXJ0aWZpY2F0ZSBsb2NhdGlvbjoKY2FfY2VydF9kaXIgPSAvZXRjL3Joc20vY2EvCgojIERlZmF1bHQgQ0EgY2VydCB0byB1c2Ugd2hlbiBnZW5lcmF0aW5nIHl1bSByZXBvIGNvbmZpZ3M6CnJlcG9fY2FfY2VydCA9ICUoY2FfY2VydF9kaXIpc3JlZGhhdC11ZXAucGVtCgojIFdoZXJlIHRoZSBjZXJ0aWZpY2F0ZXMgc2hvdWxkIGJlIHN0b3JlZApwcm9kdWN0Q2VydERpciA9IC9ldGMvcGtpL3Byb2R1Y3QKZW50aXRsZW1lbnRDZXJ0RGlyID0gL2V0Yy9wa2kvZW50aXRsZW1lbnQKY29uc3VtZXJDZXJ0RGlyID0gL2V0Yy9wa2kvY29uc3VtZXIKCiMgTWFuYWdlIGdlbmVyYXRpb24gb2YgeXVtIHJlcG9zaXRvcmllcyBmb3Igc3Vic2NyaWJlZCBjb250ZW50OgptYW5hZ2VfcmVwb3MgPSAxCgojIFJlZnJlc2ggcmVwbyBmaWxlcyB3aXRoIHNlcnZlciBvdmVycmlkZXMgb24gZXZlcnkgeXVtIGNvbW1hbmQKZnVsbF9yZWZyZXNoX29uX3l1bSA9IDAKCiMgSWYgc2V0IHRvIHplcm8sIHRoZSBjbGllbnQgd2lsbCBub3QgcmVwb3J0IHRoZSBwYWNrYWdlIHByb2ZpbGUgdG8KIyB0aGUgc3Vic2NyaXB0aW9uIG1hbmFnZW1lbnQgc2VydmljZS4KcmVwb3J0X3BhY2thZ2VfcHJvZmlsZSA9IDEKCiMgVGhlIGRpcmVjdG9yeSB0byBzZWFyY2ggZm9yIHN1YnNjcmlwdGlvbiBtYW5hZ2VyIHBsdWdpbnMKcGx1Z2luRGlyID0gL3Vzci9zaGFyZS9yaHNtLXBsdWdpbnMKCiMgVGhlIGRpcmVjdG9yeSB0byBzZWFyY2ggZm9yIHBsdWdpbiBjb25maWd1cmF0aW9uIGZpbGVzCnBsdWdpbkNvbmZEaXIgPSAvZXRjL3Joc20vcGx1Z2luY29uZi5kCgojIE1hbmFnZSBhdXRvbWF0aWMgZW5hYmxpbmcgb2YgeXVtL2RuZiBwbHVnaW5zIChwcm9kdWN0LWlkLCBzdWJzY3JpcHRpb24tbWFuYWdlcikKYXV0b19lbmFibGVfeXVtX3BsdWdpbnMgPSAxCgojIFJ1biB0aGUgcGFja2FnZSBwcm9maWxlIG9uIGVhY2ggeXVtL2RuZiB0cmFuc2FjdGlvbgpwYWNrYWdlX3Byb2ZpbGVfb25fdHJhbnMgPSAwCgojIElub3RpZnkgaXMgdXNlZCBmb3IgbW9uaXRvcmluZyBjaGFuZ2VzIGluIGRpcmVjdG9yaWVzIHdpdGggY2VydGlmaWNhdGVzLgojIEN1cnJlbnRseSBvbmx5IHRoZSAvZXRjL3BraS9jb25zdW1lciBkaXJlY3RvcnkgaXMgbW9uaXRvcmVkIGJ5IHRoZQojIHJoc20uc2VydmljZS4gV2hlbiB0aGlzIGRpcmVjdG9yeSBpcyBtb3VudGVkIHVzaW5nIGEgbmV0d29yayBmaWxlIHN5c3RlbQojIHdpdGhvdXQgaW5vdGlmeSBub3RpZmljYXRpb24gc3VwcG9ydCAoZS5nLiBORlMpLCB0aGVuIGRpc2FibGluZyBpbm90aWZ5CiMgaXMgc3Ryb25nbHkgcmVjb21tZW5kZWQuIFdoZW4gaW5vdGlmeSBpcyBkaXNhYmxlZCwgcGVyaW9kaWNhbCBkaXJlY3RvcnkKIyBwb2xsaW5nIGlzIHVzZWQgaW5zdGVhZC4KaW5vdGlmeSA9IDEKCltyaHNtY2VydGRdCiMgSW50ZXJ2YWwgdG8gcnVuIGNlcnQgY2hlY2sgKGluIG1pbnV0ZXMpOgpjZXJ0Q2hlY2tJbnRlcnZhbCA9IDI0MAojIEludGVydmFsIHRvIHJ1biBhdXRvLWF0dGFjaCAoaW4gbWludXRlcyk6CmF1dG9BdHRhY2hJbnRlcnZhbCA9IDE0NDAKIyBJZiBzZXQgdG8gemVybywgdGhlIGNoZWNrcyBkb25lIGJ5IHRoZSByaHNtY2VydGQgZGFlbW9uIHdpbGwgbm90IGJlIHNwbGF5ZWQgKHJhbmRvbWx5IG9mZnNldCkKc3BsYXkgPSAxCiMgSWYgc2V0IHRvIDEsIHJoc21jZXJ0ZCB3aWxsIG5vdCBleGVjdXRlLgpkaXNhYmxlID0gMAoKW2xvZ2dpbmddCmRlZmF1bHRfbG9nX2xldmVsID0gSU5GTwojIHN1YnNjcmlwdGlvbl9tYW5hZ2VyID0gREVCVUcKIyBzdWJzY3JpcHRpb25fbWFuYWdlci5tYW5hZ2VyY2xpID0gREVCVUcKIyByaHNtID0gREVCVUcKIyByaHNtLmNvbm5lY3Rpb24gPSBERUJVRwojIHJoc20tYXBwID0gREVCVUcKIyByaHNtLWFwcC5yaHNtZCA9IERFQlVHCg==
+        filesystem: root
+        mode: 0644
+        path: /etc/rhsm/rhsm.conf
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: {{ role }}
+  name: 50-{{ role }}-entitlement-pem
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,{{ entitlement_base64 }}
+        filesystem: root
+        mode: 0644
+        path: /etc/pki/entitlement/entitlement.pem
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: {{ role }}
+  name: 50-{{ role }}-entitlement-key-pem
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,{{ entitlement_key_base64 }}
+        filesystem: root
+        mode: 0644
+        path: /etc/pki/entitlement/entitlement-key.pem
+

--- a/ansible/add-on-roles/web-terminal/.travis.yml
+++ b/ansible/add-on-roles/web-terminal/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/ansible/add-on-roles/web-terminal/README.md
+++ b/ansible/add-on-roles/web-terminal/README.md
@@ -1,0 +1,38 @@
+web-termin
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example config
+----------------
+
+```
+post_install_add_ons:
+  - name: 'web-terminal'
+    tasks_from: 'post-install.yml'
+```
+
+License
+-------
+
+Apache 2.0
+
+Author Information
+------------------
+
+Robert Bohne

--- a/ansible/add-on-roles/web-terminal/defaults/main.yml
+++ b/ansible/add-on-roles/web-terminal/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for web-terminal

--- a/ansible/add-on-roles/web-terminal/handlers/main.yml
+++ b/ansible/add-on-roles/web-terminal/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for web-terminal

--- a/ansible/add-on-roles/web-terminal/meta/main.yml
+++ b/ansible/add-on-roles/web-terminal/meta/main.yml
@@ -1,0 +1,53 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.9
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+  

--- a/ansible/add-on-roles/web-terminal/tasks/main.yml
+++ b/ansible/add-on-roles/web-terminal/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+# tasks file for web-terminal

--- a/ansible/add-on-roles/web-terminal/tasks/post-install.yml
+++ b/ansible/add-on-roles/web-terminal/tasks/post-install.yml
@@ -1,0 +1,21 @@
+---
+
+- name: Apply web-terminal subscription
+  k8s:
+    state: present
+    kubeconfig: "{{ k8s_kubeconfig }}"
+    host: "{{ k8s_host }}"
+    ca_cert: "{{ k8s_ca_cert }}"
+    client_cert: "{{ k8s_client_cert }}"
+    client_key: "{{ k8s_client_key }}"
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: web-terminal
+        namespace: openshift-operators
+      spec:
+        channel: alpha
+        name: web-terminal
+        source: redhat-operators
+        sourceNamespace: openshift-marketplace

--- a/ansible/add-on-roles/web-terminal/tests/inventory
+++ b/ansible/add-on-roles/web-terminal/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/ansible/add-on-roles/web-terminal/tests/test.yml
+++ b/ansible/add-on-roles/web-terminal/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - web-terminal

--- a/ansible/add-on-roles/web-terminal/vars/main.yml
+++ b/ansible/add-on-roles/web-terminal/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for web-terminal

--- a/ansible/roles/openshift-4-cluster/defaults/main.yml
+++ b/ansible/roles/openshift-4-cluster/defaults/main.yml
@@ -78,3 +78,5 @@ sdn_plugin_name: OVNKubernetes
 
 # Master node schedulable
 masters_schedulable: true
+
+add_ons_enabled: false

--- a/ansible/roles/openshift-4-cluster/tasks/create.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/create.yml
@@ -1,4 +1,23 @@
 ---
+
+- name: Check add-ons.yml
+  stat:
+    path: "{{ playbook_dir }}/../add-ons.yml"
+  register: add_ons_yml
+  tags:
+    - post-install
+    - add-ons
+    - post-install-add-ons
+
+- name: Enable add-ons
+  set_fact:
+    add_ons_enabled: true
+  when: add_ons_yml.stat.exists
+  tags:
+    - post-install
+    - add-ons
+    - post-install-add-ons
+
 - import_tasks: create-network.yml
   vars:
     vn_public_domain: "{{ cluster_name }}.{{ public_domain }}"

--- a/ansible/roles/openshift-4-cluster/tasks/post-install-add-ons.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/post-install-add-ons.yml
@@ -1,0 +1,13 @@
+---
+- name: Include vars of stuff.yaml into the 'stuff' variable (2.2).
+  include_vars: "{{ playbook_dir }}/../add-ons.yml"
+
+- name: "Handle post_install_add_ons (include_role)"
+  include_role:
+    name: "{{ item.name }}"
+    tasks_from: "{{ item.tasks_from | default('main.yml') }}"
+  tags:
+    - post-install
+    - add-ons
+    - post-install-add-ons
+  with_items: "{{ post_install_add_ons | default ([]) }}"

--- a/ansible/roles/openshift-4-cluster/tasks/post-install.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/post-install.yml
@@ -30,6 +30,10 @@
 
 - name: Build k8s variables
   import_tasks: build-k8s-vars.yml
+  tags:
+    - post-install
+    - add-ons
+    - post-install-add-ons
 
 - name: Provision nfs storage
   import_tasks: post-install-storage-nfs.yml
@@ -241,6 +245,18 @@
   tags:
     - post-install
     - rolebindings
+
+###########################################################################################
+# Handle post-install-add-ons
+###########################################################################################
+
+- name: Include post-install-add-ons
+  include: post-install-add-ons.yml
+  when: add_ons_enabled
+  tags:
+    - post-install
+    - add-ons
+    - post-install-add-ons
 
 ###########################################################################################
 # Print Cluster informations

--- a/ansible/run-add-ons.yml
+++ b/ansible/run-add-ons.yml
@@ -1,0 +1,18 @@
+#!/usr/bin/env ansible-playbook
+---
+
+- name: Test
+  hosts: localhost
+  connection: local
+  # gather_facts: no
+  vars_files:
+  - ../cluster.yml
+  vars:
+    # post_install_add_ons:
+    #   nvidia-gpu: "post-install.yaml"
+  tasks:
+    - import_role:
+        name: openshift-4-cluster
+        tasks_from: "post-install-add-ons.yml"
+      when: add_ons_enabled
+      tags: add-ons

--- a/docs/add-ons.md
+++ b/docs/add-ons.md
@@ -1,0 +1,130 @@
+# Add-ons (post_install_add_ons)
+
+A cluster can be adapted from the standard installation with add-ons. The aim is to keep hetzner-ocp4 as lean as possible.
+
+Technically, add-ons are simply ansible roles that are dynamically integrated. So you can write your own.
+
+We deliver a few add-ons in the directory `ansible/add-on-role` ready to use or learn how to write your own.
+
+## How to use an add-on
+
+We use the web terminal add-on as an example. (ansible/add-on-roles/web-terminal/)[./ansible/add-on-roles/web-terminal/]
+
+### Create add-ons.yml to enable & configure add on(s)
+
+```bash
+cat > add-ons.yml <<EOF
+post_install_add_ons:
+  - name: 'web-terminal'
+    # Default is main.yml
+    tasks_from: 'post-install.yml'
+EOF
+```
+
+Next step simple install your cluster as usual.
+
+## How to create your own add-on
+
+I recommend to use git to store your role and install to hetzner host.
+
+### Create an role & push to github
+
+#### Create emptry role and push to git server
+```bash
+# Create new git repo on GitHub - don't forget to add license
+
+$ git clone git@github.com:RedHat-EMEA-SSA-Team/hetzner-ocp4-add-on-example.git
+$ cd  hetzner-ocp4-add-on-example
+$ ansible-galaxy role init --offline hetzner-ocp4-add-on-example
+- Role hetzner-ocp4-add-on-example was created successfully
+
+$ mv hetzner-ocp4-add-on-example/* .
+$ mv hetzner-ocp4-add-on-example/.travis.yml .
+$ rmdir hetzner-ocp4-add-on-example
+
+$ git add .
+$ git commit -m 'inital ansible role'
+$ git push
+```
+
+#### Add content to tasks/main.yml
+
+Here an example of tasks/main.yml
+
+```yaml
+---
+# tasks file for hetzner-ocp4-add-on-example
+- name: Create namespace
+  k8s:
+    state: present
+    kubeconfig: "{{ k8s_kubeconfig }}"
+    host: "{{ k8s_host }}"
+    ca_cert: "{{ k8s_ca_cert }}"
+    client_cert: "{{ k8s_client_cert }}"
+    client_key: "{{ k8s_client_key }}"
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: hetzner-ocp4-add-on-example
+
+- name: Create Deployment
+  k8s:
+    state: present
+    kubeconfig: "{{ k8s_kubeconfig }}"
+    host: "{{ k8s_host }}"
+    ca_cert: "{{ k8s_ca_cert }}"
+    client_cert: "{{ k8s_client_cert }}"
+    client_key: "{{ k8s_client_key }}"
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: busybox
+        namespace: hetzner-ocp4-add-on-example
+        labels:
+          app: busybox
+      spec:
+        replicas: 3
+        selector:
+          matchLabels:
+            app: busybox
+        template:
+          metadata:
+            labels:
+              app: busybox
+          spec:
+            containers:
+            - name: busybox
+              image: busybox
+              command: [ "/bin/sh", "-c", "while true ; do date; sleep 1; done;" ]
+
+```
+
+Add, commit and push the changes
+
+### Install and configure the role
+
+[Install role wie CLI argument or requirements.yml](https://galaxy.ansible.com/docs/using/installing.html)
+
+```bash
+$ ansible-gala xy install git+https://github.com/RedHat-EMEA-SSA-Team/hetzner-ocp4-add-on-example.git
+- extracting hetzner-ocp4-add-on-example to /root/.ansible/roles/hetzner-ocp4-add-on-example
+- hetzner-ocp4-add-on-example was installed successfully
+```
+
+Create add-ons.yml:
+```bash
+cat > add-ons.yml <<EOF
+post_install_add_ons:
+  - name: hetzner-ocp4-add-on-example
+EOF
+```
+
+Next step simple install your cluster as usual.
+
+## How to apply add-on to running cluster or re-apply
+
+Create `add-ons.yaml` as described above.
+
+Run `./ansible/02-create-cluster.yml --tags post-install-add-ons`


### PR DESCRIPTION
## Description

Add support to add private post install roles for example `hetzner-ocp4-add-on-cluster-entitlement`:

cluster.yml
```yaml
post_install_add_ons:
  - name: cluster-entitlement
    tasks_from: "post-install.yaml"

entitlement_id: 7045354189760625103
```

### Ansible role  `hetzner-ocp4-add-on-cluster-entitlement`

#### Role tree
```
hetzner-ocp4-add-on-cluster-entitlement/
├── README.md
├── tasks
│   ├── entitlement-from-rhel-node.yaml
│   └── post-install.yaml
└── templates
    └── 0003-cluster-wide-machineconfigs.yaml.j2
```

#### post-install.yaml
```yaml
---
- name: GPU Post install
  debug:
    msg: "Run cluster entitlement against {{ kubeconfig }}"

- name: "Include entitlement-from-rhel-node.yaml"
  include: "entitlement-from-rhel-node.yaml"
  when: ansible_distribution  == "RedHat"
```

#### entitlement-from-rhel-node.yaml
```yaml
[... snipped...]
- name: Apply entitle machineconfig
  k8s:
    state: present
    kubeconfig: "{{ kubeconfig }}"
    definition: "{{ lookup('template', 'templates/0003-cluster-wide-machineconfigs.yaml.j2') }}"
  vars:
    entitlement_key_base64: "{{ register_entitlement_key_base64.stdout }}"
    entitlement_base64: "{{ register_entitlement_base64.stdout }}"
    role: "{{ loop_role }}"
  with_items:
    - master
    - worker
  loop_control:
    loop_var: loop_role
```

## Checklist/ToDo's

- [ ] Added documentation?
- [ ] Added release note entry? (  docs/release-notes.md )
- [ ] Tested? 