### PR TITLE
Bump OpenShift to 4.5.16

### DIFF
--- a/ansible/roles/openshift-4-cluster/defaults/main.yml
+++ b/ansible/roles/openshift-4-cluster/defaults/main.yml
@@ -31,7 +31,7 @@ vm_autostart: false
 # Important: OpenShift version must match to RHEL CoreOS version!
 
 # reference to OpenShift version
-openshift_version: 4.5.2
+openshift_version: 4.5.16
 openshift_install_command: "/opt/openshift-install-{{ openshift_version }}/openshift-install"
 # dev-pre:
 # https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview
@@ -42,7 +42,7 @@ openshift_client_version: "{{ openshift_version }}"
 openshift_location: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{openshift_client_version}}"
 
 # reference to coreos qcow file
-coreos_version: 4.5.2
+coreos_version: 4.5.6
 coreos_download_url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/{{ coreos_version.split('.')[:2]|join('.') }}/{{ coreos_version }}/rhcos-{{coreos_version}}-x86_64-qemu.x86_64.qcow2.gz"
 coreos_csum_url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/{{ coreos_version.split('.')[:2]|join('.') }}/{{ coreos_version }}/sha256sum.txt"
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,10 @@
 # RELEASE NOTES
 
+## 2020-11-04
+
+### Bump OpenShift Version to 4.5.16
+[Changelog](https://docs.openshift.com/container-platform/4.5/release_notes/ocp-4-5-release-notes.html#ocp-4-5-16)
+
 ## 2020-09-24
 
 ### Update


### PR DESCRIPTION
## Description
Bump OpenShift to 4.5.16
[Changelog](https://docs.openshift.com/container-platform/4.5/release_notes/ocp-4-5-release-notes.html#ocp-4-5-16)

## Checklist/ToDo's

- [x] Added documentation?
- [x] Added release note entry? (  docs/release-notes.md )
- [x] Tested? 