### PR TITLE
Added an option to make masters un/schedulable

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Please configure in `cluster.yml` all necessary credentials:
 |`install_config_imageContentSources`|empty|Important for air-gapped installation. checkout [docs/air-gapped.md](docs/air-gapped.md)
 |`letsencrypt_disabled`|`false`|This allows you to disable letsencrypt setup. (Default is enabled letsencrypt.)
 |`sdn_plugin_name`|`OVNKubernetes`|This allows you to change SDN plugin. Valid values are OpenShiftSDN and OVNKubernetes. (Default is OVNKubernetes.)
+|`masters_schedulable`|false|Set to true if you wish to allow workload onto the master nodes. (Default is to disallow this)|
 
 ## Prepare kvm-host and install OpenShift
 

--- a/ansible/roles/openshift-4-cluster/defaults/main.yml
+++ b/ansible/roles/openshift-4-cluster/defaults/main.yml
@@ -73,3 +73,6 @@ storage_nfs_target_namespace: openshift-nfs-provisioner
 
 # sdn plugin
 sdn_plugin_name: OVNKubernetes
+
+# Master node schedulable
+masters_schedulable: false

--- a/ansible/roles/openshift-4-cluster/tasks/create-ignition.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/create-ignition.yml
@@ -14,7 +14,17 @@
     dest: "{{ openshift_install_dir }}/install-config.yaml.original"
     src: "{{ openshift_install_dir }}/install-config.yaml"
 
+- name: Create manifest files
+  command: "{{ openshift_install_command }} create manifests --dir={{ openshift_install_dir }}"
+  when: masters_schedulable != true
+
+- name: Make Master nodes unschedulable
+  lineinfile:
+    path: "{{ openshift_install_dir }}/manifests/cluster-scheduler-02-config.yml"
+    regexp: '^(.*)mastersSchedulable(.*)$'
+    line: '  masterSchedulable: False'
+    backrefs: yes
+  when: masters_schedulable != true
+
 - name: Create ignition files
   command: "{{ openshift_install_command }} --dir={{ openshift_install_dir }} create ignition-configs"
-  args:
-    creates: "{{ openshift_install_dir}}/.openshift_install_state.json"

--- a/cluster-example.yml
+++ b/cluster-example.yml
@@ -34,6 +34,7 @@ auth_htpasswd:
   - local:$apr1$k5WdDLwM$TzqDd.juwTiotMbctaxJt.
 
 storage_nfs: true # Default is false
+masters_schedulable: false # Default is false
 
 auth_redhatsso:
   client_id: "xxxxx.apps.googleusercontent.com"


### PR DESCRIPTION
As the master nodes were set to schedulable by default, I added an option that allows/disallows this. It adds two tasks before creating the ingition files in `create-ignitions.yml`.
An entry was added in the readme file with the optional configuration and a default value (set to false) was added to the defaults/main.yml file.

Done and tested on a CentOS 8.2 machine.

## Description


## Checklist/ToDo's

- [x] Added documentation?
- [ ] Added release note entry? (  docs/release-notes.md )
- [ ] Tested? 