### PR TITLE
Add Hetzner DNS capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Please configure in `cluster.yml` all necessary credentials:
 |Route53 / AWS|`aws_access_key: key` <br/>`aws_secret_key: secret` <br/>`aws_zone: domain.tld` <br/>|
 |GCP|`gcp_project: project-name `<br/>`gcp_managed_zone_name: 'zone-name'`<br/>`gcp_managed_zone_domain: 'example.com.'`<br/>`gcp_serviceaccount_file: ../gcp_service_account.json` |
 |Azure|`azure_client_id: 'client_id'`<br/>`azure_secret: 'key'`<br/>`azure_subscription_id: 'subscription_id'`<br/>`azure_tenant: 'tenant_id'`<br/>`azure_resource_group: 'dns_zone_resource_group'` |
+|Hetzner|`hetzner_account_api_token: 93543ade82AA$73.....` <br>  `hetzner_zone: domain.tld`|
 |none|With `dns_provider: none` the playbooks will not create public dns entries. (It will skip letsencrypt too) Please create public dns entries if you want to access your cluster.|
 
 ### Optional configuration

--- a/ansible/00-provision-hetzner.yml
+++ b/ansible/00-provision-hetzner.yml
@@ -11,6 +11,7 @@
   - name: Add hetzner server to inventory
     add_host: 
       name: "{{ hetzner_hostname }}"
+      ansible_host: '{{ hetzner_ip }}'
 
 - name: install hetzner server
   hosts: all
@@ -24,4 +25,3 @@
       name: provision-hetzner
     tags:
       - provision-hetzner
-

--- a/ansible/roles/letsencrypt/README.md
+++ b/ansible/roles/letsencrypt/README.md
@@ -1,12 +1,12 @@
 letsencrypt
 =========
 
-Create  certificates with DNS challenge through cloudflare or aws route53
+Create  certificates with DNS challenge through Cloudflare, AWS Route53, GCP Cloud DNS or Hetzner
 
 Requirements
 ------------
 
-- cloudflare account 
+- cloudflare account
 - matching domain to the certificate ;-)
 
 Role Variables
@@ -14,10 +14,10 @@ Role Variables
 
 | variable | describtion  | example | default | 
 |---|---|---|---|
-| le_dns_provider | DNS provider | `[cloudflare|route53]` |  non **required** |
-| le_cloudflare_account_email | Cloudflare Account E-Mail for API authentication | `account@domain.tld`| non **required if provider is  cloudflare** |
-| le_cloudflare_account_api_token | Cloudflare API token for API authentication | `loo...ngiJ`| non **required if provider is  cloudflare** |
-| le_cloudflare_zone | Cloudflare zone in which the entries are created and deleted for the dns challenge | `domain.tld` | non **required if provider is  cloudflare** |
+| le_dns_provider | DNS provider | `[route53|cloudflare|gcp|azure|hetzner]` |  non **required** |
+| le_cloudflare_account_email | Cloudflare Account E-Mail for API authentication | `account@domain.tld`| non **required if provider is cloudflare** |
+| le_cloudflare_account_api_token | Cloudflare API token for API authentication | `loo...ngiJ`| non **required if provider is cloudflare** |
+| le_cloudflare_zone | Cloudflare zone in which the entries are created and deleted for the dns challenge | `domain.tld` | non **required if provider is cloudflare** |
 | le_aws_access_key | AWS Access key | |  non **required if provider is  route53** |
 | le_aws_secret_key | AWS secret key || non **required if provider is  route53** |
 | le_aws_zone | AWS route 53 zonename || non **required if provider is  route53** |
@@ -25,6 +25,8 @@ Role Variables
 | le_gcp_serviceaccount_file | GCP DNS serviceaccount file || non **required if provider is  gcp** |
 | le_gcp_managed_zone_name | GCP DNS managed zone name || non **required if provider is  gcp** |
 | le_gcp_managed_zone_domain | GCP DNS managed zone domain || non **required if provider is  gcp** |
+| le_hetzner_account_api_token | Hetzner API token for API authentication | `jdu...zalU`| non **required if provider is hetzner** |
+| le_hetzner_zone | Hetzner zone in which the entries are created and deleted for the dns challenge | `domain.tld` | non **required if provider is hetzner** |
 | le_public_domain | Use to create SAN certificate: `DNS:*.apps.{{ le_public_domain }},DNS:api.{{ le_public_domain }}` | cluster.domain.tld | non **required** |
 | le_certificates_dir | Here the certificates are stored  | `/root/certificates` | `{{ playbook_dir }}../certificate/` |
 | le_acme_directory | ACME Directory by default it use staging env because of https://letsencrypt.org/docs/rate-limits/ | `https://acme-v02.api.letsencrypt.org/directory` | `https://acme-staging-v02.api.letsencrypt.org/directory` |
@@ -35,7 +37,7 @@ Dependencies
 TBD
 
 - openssl_privatekey
-    - Either cryptography >= 1.2.3 (older versions might work as well) 
+    - Either cryptography >= 1.2.3 (older versions might work as well)
     - Or pyOpenSSL
 
 Example Playbook
@@ -73,7 +75,6 @@ Example in context of hetzner-ocp4
     # lc_acme_directory: "https://acme-v02.api.letsencrypt.org/directory"
 
 ```
-
 
 Author Information
 ------------------

--- a/ansible/roles/letsencrypt/tasks/check-variables.yml
+++ b/ansible/roles/letsencrypt/tasks/check-variables.yml
@@ -55,6 +55,16 @@
     - le_azure_resource_group
   when: le_dns_provider == "azure"
 
+- name: Check required Hetzner variables
+  assert:
+    that:
+      - lookup('vars',item) is defined
+    msg: "{{ item }} is not defined!"
+  with_items:
+    - le_hetzner_account_api_token
+    - le_hetzner_zone
+  when: le_dns_provider == "hetzner"
+
 - name: Debug var only with -vv CloudFlare
   debug:
     msg: "{{ item }}={{ lookup('vars',item) }}"
@@ -114,3 +124,12 @@
     - le_public_domain
     - le_acme_directory
   when: le_dns_provider == "azure"
+
+- name: Debug var only with -vv for Hetzner
+  debug:
+    msg: "{{ item }}={{ lookup('vars',item) }}"
+    verbosity: 2
+  with_items:
+    - le_hetzner_account_api_token
+    - le_hetzner_zone
+  when: le_dns_provider == "hetzner"

--- a/ansible/roles/letsencrypt/tasks/main.yml
+++ b/ansible/roles/letsencrypt/tasks/main.yml
@@ -119,6 +119,39 @@
   loop: "{{ challenge_data_dns | default({}) | dict2items | subelements('value') }}"
   when: le_dns_provider == "azure" and sample_com_challenge is changed
 
+- name: Get DNS zone id at Hetzner
+  uri:
+    url: "https://dns.hetzner.com/api/v1/zones"
+    body_format: json
+    return_content: true
+    body:
+      name: "{{ le_hetzner_zone }}"
+    headers:
+      Auth-API-Token: "{{ hetzner_account_api_token }}"
+      Content-Type: 'application/json'
+  register: le_hetzner_zone_id
+  tags:
+    - public_dns
+
+- name: Create DNS record at Hetzner
+  uri:
+    url: "https://dns.hetzner.com/api/v1/records"
+    method: POST
+    body_format: json
+    return_content: true
+    body:
+      value: "{{ item.1 }}"
+      ttl: 60
+      type: TXT
+      name: "{{ item.0.key | replace(public_domain, '') | regex_replace('\\.$', '') }}"
+      zone_id: "{{ le_hetzner_zone_id.json.zones | json_query('[*].id') | join(', ') }}"
+    headers:
+      Auth-API-Token: "{{ le_hetzner_account_api_token }}"
+      Content-Type: 'application/json'
+  register: record
+  loop: "{{ challenge_data_dns | default({}) | dict2items | subelements('value') }}"
+  when: le_dns_provider == "hetzner" and sample_com_challenge is changed
+
 - name: DNS record info
   debug:
     msg: "{{ item.0.key }} TXT {{ item.1 }}"
@@ -205,6 +238,24 @@
   register: record
   loop: "{{ challenge_data_dns | default({}) | dict2items | subelements('value') }}"
   when: le_dns_provider == "azure" and sample_com_challenge is changed
+
+# - name: Delete DNS record at Hetzner
+#   uri:
+#     url: "https://dns.hetzner.com/api/v1/records/{{ record }}"
+#     method: DELETE
+#     headers:
+#       Auth-API-Token: "{{ le_hetzner_account_api_token }}"
+#       Content-Type: 'application/json'
+#     body_format: json
+#     body:
+#       value: "{{ item.1 }}"
+#       ttl: 60
+#       type: TXT
+#       name: "{{ item.0.key }}"
+#       zone_id: "{{ le_hetzner_zone_id.json.zones | json_query('[*].id') | join(', ') }}"
+#   register: record
+#   loop: "{{ challenge_data_dns | default({}) | dict2items | subelements('value') }}"
+#   when: le_dns_provider == "hetzner" and sample_com_challenge is changed
 
 - name: concat root ca and intermediate
   shell: "cat {{ le_certificates_dir }}/isrgrootx1.pem {{ le_certificates_dir }}/{{ le_public_domain }}/intermediate.crt >> {{ le_certificates_dir }}/{{ le_public_domain }}/ca-bundle.pem"

--- a/ansible/roles/openshift-4-cluster/tasks/certificate-renewal.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/certificate-renewal.yml
@@ -24,5 +24,8 @@
     le_gcp_serviceaccount_file: "{{ gcp_serviceaccount_file }}"
     le_gcp_managed_zone_name: "{{ gcp_managed_zone_name }}"
     le_gcp_managed_zone_domain: "{{ gcp_managed_zone_domain }}"
+
+    le_hetzner_account_api_token: "{{ hetzner_account_api_token }}"
+    le_hetzner_zone: "{{ hetzner_zone }}"
   tags: letsencrypt
   when: letsencrypt_disabled == false

--- a/ansible/roles/openshift-4-cluster/tasks/create-network.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/create-network.yml
@@ -92,6 +92,8 @@
     pd_aws_access_key: "{{ aws_access_key }}"
     pd_aws_secret_key: "{{ aws_secret_key }}"
     pd_aws_zone: "{{ aws_zone }}"
+    pd_hetzner_account_api_token: "{{ hetzner_account_api_token }}"
+    pd_hetzner_zone: "{{ hetzner_zone }}"
     pd_public_domain: "{{ cluster_name }}.{{ public_domain }}"
   tags: public_dns
   when: dns_provider != 'none'

--- a/ansible/roles/openshift-4-cluster/tasks/create.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/create.yml
@@ -62,6 +62,9 @@
     le_azure_tenant: "{{ azure_tenant }}"
     le_azure_resource_group:  "{{ azure_resource_group }}"
 
+    le_hetzner_account_api_token: "{{ hetzner_account_api_token }}"
+    le_hetzner_zone: "{{ hetzner_zone }}"
+
   tags: letsencrypt
   when: letsencrypt_disabled == false
 

--- a/ansible/roles/openshift-4-cluster/tasks/destroy-network.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/destroy-network.yml
@@ -11,6 +11,8 @@
     pd_aws_access_key: "{{ aws_access_key }}"
     pd_aws_secret_key: "{{ aws_secret_key }}"
     pd_aws_zone: "{{ aws_zone }}"
+    pd_hetzner_account_api_token: "{{ hetzner_account_api_token }}"
+    pd_hetzner_zone: "{{ hetzner_zone }}"
     pd_public_domain: "{{ cluster_name }}.{{ public_domain }}"
   tags: public_dns
   when: dns_provider != 'none'

--- a/ansible/roles/openshift-4-cluster/tasks/download-openshift-artifacts.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/download-openshift-artifacts.yml
@@ -58,6 +58,9 @@
         dest: "{{ coreos_path }}/{{ coreos_download_url | basename }}"
         checksum: "sha256:{{ coreos_csum_str }}"
       register: coreos_download
+      until: coreos_download is not failed
+      retries: 3
+      delay: 15
 
     - name: Get filetype
       stat:
@@ -126,6 +129,10 @@
     url: "{{ helm_cli_location }}"
     mode: u+rwx,g+rx,o+rx
     dest: "/opt/openshift-client-{{ openshift_version }}/helm"
+  register: helm_download
+  until: helm_download is not failed
+  retries: 3
+  delay: 15
 
 - name: Create a symbolic link
   file:

--- a/ansible/roles/openshift-4-cluster/tasks/post-install.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/post-install.yml
@@ -38,6 +38,7 @@
     - storage
     - idp
     - rolebindings
+    - always
 
 - name: Provision nfs storage
   import_tasks: post-install-storage-nfs.yml

--- a/ansible/roles/openshift-4-cluster/tasks/prepare-host-CentOS-8.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/prepare-host-CentOS-8.yml
@@ -38,7 +38,6 @@
     - rpc-bind
   notify: 'reload firewalld'
 
-#
 - name: Allow OpenShift traffic from VM's to Host
   firewalld:
     zone: libvirt

--- a/ansible/roles/provision-hetzner/tasks/main.yml
+++ b/ansible/roles/provision-hetzner/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Check rescue mode
   uri:
-    url: "https://robot-ws.your-server.de/boot/{{ hetzner_ip }}/rescue"
+    url: "https://robot-ws.your-server.de/boot/{{ ansible_host }}/rescue"
     method: GET
     user: "{{ hetzner_webservice_username }}"
     password: "{{ hetzner_webservice_password }}"
@@ -27,23 +27,22 @@
   delegate_to: localhost
 
 - name: Activate rescue mode
-  when:  rescue.json.rescue.active == false
+  when: rescue.json.rescue.active == false
   uri:
-    url: "https://robot-ws.your-server.de/boot/{{ hetzner_ip }}/rescue"
+    url: "https://robot-ws.your-server.de/boot/{{ ansible_host }}/rescue"
     method: POST
     user: "{{ hetzner_webservice_username }}"
     password: "{{ hetzner_webservice_password }}"
     force_basic_auth: yes
     body: "os=linux&arch=64&authorized_key={{ authorized_key }}"
+    body_format: form-urlencoded
     status_code: 200
-    headers:
-      Content_Type: "application/x-www-form-urlencoded"
   register: activated
   delegate_to: localhost
 
 - name: Execute hardware reset
   uri:
-    url: "https://robot-ws.your-server.de/reset/{{ hetzner_ip }}"
+    url: "https://robot-ws.your-server.de/reset/{{ ansible_host }}"
     method: POST
     user: "{{ hetzner_webservice_username }}"
     password: "{{ hetzner_webservice_password }}"
@@ -55,9 +54,7 @@
   delegate_to: localhost
 
 - name: Remove server from local known_hosts file
-  local_action:
-    module: command
-    cmd: "/usr/bin/ssh-keygen -R {{ inventory_hostname }}"
+  local_action: command /usr/bin/ssh-keygen -R {{ ansible_host }}
   ignore_errors: yes
 
 - name: Pause a bit for the hardware reset to kick in
@@ -66,7 +63,7 @@
 - name: Wait 300 seconds for port 22 to become open
   wait_for:
     port: 22
-    host: '{{ inventory_hostname }}'
+    host: '{{ ansible_host }}'
     delay: 10
     timeout: 300
   connection: local
@@ -88,7 +85,7 @@
   command: "/root/.oldroot/nfs/install/installimage -a -c /root/autosetup"
   environment:
     TERM: "vt100"
-  ignore_errors: true
+  ignore_errors: yes
   register: result
 
 - debug:
@@ -116,13 +113,13 @@
   ignore_errors: yes
 
 - name: Remove server from local known_hosts file
-  local_action: command  /usr/bin/ssh-keygen -R {{ inventory_hostname }}
+  local_action: command /usr/bin/ssh-keygen -R {{ ansible_host }}
   ignore_errors: yes
 
 - name: Wait 300 seconds for port 22 to become open
   wait_for:
     port: 22
-    host: '{{ inventory_hostname }}'
+    host: '{{ ansible_host }}'
     delay: 10
     timeout: 300
   connection: local
@@ -130,7 +127,7 @@
 - name: Check ansible_python_interpreter
   ping:
   register: rc
-  ignore_errors: true
+  ignore_errors: yes
 
 - name: Set ansible_python_interpreter to /usr/libexec/platform-python (RHEL 8)
   set_fact:
@@ -147,3 +144,38 @@
   systemd:
     name: sshd.service
     state: restarted
+
+- name: Prepare host
+  block:
+  - name: Install required packages
+    yum:
+      name:
+        - ansible
+        - git
+
+  - name: Create temp directory
+    tempfile:
+      state: directory
+    register: temp_dir
+
+  - name: Synchronize files
+    synchronize:
+      src: "{{ playbook_dir }}"
+      dest:  "{{ temp_dir.path }}"
+      delete: yes
+      recursive: yes
+
+  - name: Synchronize cluster.yml
+    synchronize:
+      src: "{{ playbook_dir }}/../cluster.yml"
+      dest:  "{{ temp_dir.path }}/cluster.yml"
+      recursive: yes
+      delete: yes
+
+  - name: Installation command info
+    debug:
+      msg:
+        - "Run setup on {{ ansible_host }} by running"
+        - "pushd {{ temp_dir.path }}/ansible"
+        - "ansible-playbook setup.yml"
+  when: hetzner_provision_prepare_host

--- a/ansible/roles/public_dns/tasks/create-cloudflare.yml
+++ b/ansible/roles/public_dns/tasks/create-cloudflare.yml
@@ -1,5 +1,5 @@
 ---
-- name: create cloudflare DNS records
+- name: Create Cloudflare DNS records
   cloudflare_dns:
     zone: "{{ pd_cloudflare_zone }}"
     record: "{{ item }}.{{ pd_public_domain }}"

--- a/ansible/roles/public_dns/tasks/create-hetzner.yml
+++ b/ansible/roles/public_dns/tasks/create-hetzner.yml
@@ -1,0 +1,56 @@
+---
+- name: Get DNS zone id at Hetzner
+  uri:
+    url: "https://dns.hetzner.com/api/v1/zones"
+    body_format: json
+    return_content: true
+    body:
+      name: "{{ pd_hetzner_zone }}"
+    headers:
+      Auth-API-Token: "{{ hetzner_account_api_token }}"
+      Content-Type: 'application/json'
+  register: pd_hetzner_zone_id
+  tags:
+    - public_dns
+
+- name: Create DNS record at Hetzner
+  uri:
+    url: "https://dns.hetzner.com/api/v1/records"
+    method: POST
+    body_format: json
+    return_content: true
+    body:
+      value: "{{ pd_public_ip }}"
+      ttl: 120
+      type: A
+      name: "{{ item }}.{{ pd_public_domain | replace(public_domain, '') | regex_replace('\\.$', '') }}"
+      zone_id: "{{ pd_hetzner_zone_id.json.zones | json_query('[*].id') | join(', ') }}"
+    headers:
+      Auth-API-Token: "{{ hetzner_account_api_token }}"
+      Content-Type: 'application/json'
+  with_items:
+  - api
+  - '*.apps'
+  tags:
+    - public_dns
+
+- name: Check reverse DNS entry at Hetzner
+  uri:
+    user: "{{ hetzner_webservice_username }}"
+    password: "{{ hetzner_webservice_password }}"
+    url: "https://robot-ws.your-server.de/rdns/{{ hetzner_ip }}"
+    status_code: [200, 404]
+  register: pd_rdns_entry
+
+- name: Update reverse DNS entry at Hetzner
+  uri:
+    user: "{{ hetzner_webservice_username }}"
+    password: "{{ hetzner_webservice_password }}"
+    url: "https://robot-ws.your-server.de/rdns/{{ hetzner_ip }}"
+    method: POST
+    body:
+      ptr: "{{ hetzner_hostname }}"
+    body_format: form-urlencoded
+    status_code: [200, 201]
+  changed_when: '"rdns" not in pd_rdns_entry.json or hetzner_hostname != pd_rdns_entry.json.rdns.ptr'
+  when: '"rdns" not in pd_rdns_entry.json or hetzner_hostname != pd_rdns_entry.json.rdns.ptr'

--- a/ansible/roles/public_dns/tasks/create.yml
+++ b/ansible/roles/public_dns/tasks/create.yml
@@ -1,4 +1,3 @@
 ---
-
 - name: Include DNS provider
   include: "create-{{ pd_provider }}.yml"

--- a/cluster-example.yml
+++ b/cluster-example.yml
@@ -3,7 +3,7 @@ cluster_name: ocp4
 public_domain: example.com
 # set custom public ip for DNS entries. Defaults to: hostvars['localhost']['ansible_default_ipv4']['address']
 # public_ip: 92.100.42.2
-dns_provider: [route53|cloudflare|gcp|azure]
+dns_provider: [route53|cloudflare|gcp|azure|hetzner]
 letsencrypt_account_email: name@example.com
 # Depending on the dns provider:
 # CloudFlare
@@ -26,6 +26,9 @@ azure_secret: key
 azure_subscription_id: subscription_id
 azure_tenant: tenant_id
 azure_resource_group: dns_zone_resource_group
+#Hetzner
+hetzner_account_api_token: 3543ade82AA$73.....
+hetzner_zone: example.com
 
 # Created with: htpasswd -nb admin openshift
 # Example password is openshift

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -83,6 +83,15 @@ cloudflare_account_api_token: xxxxx
 cloudflare_zone: example.com
 ```
 
+#### hetzner-cluster.yml
+```yaml
+cluster_name: test
+public_domain: hetzner.ci.example.com
+dns_provider: hetzner
+
+hetzner_account_api_token: xxxxx
+hetzner_zone: example.com
+```
 
 ## Install pipeline
 


### PR DESCRIPTION
## Description
- Add capabilities to setup DNS at hetzner
- Add option to prepare hetzner host without pipeline
- Add retry mechanism to avoid failures on mirror.openshift.com

## Checklist/ToDo's

- [x] Added documentation?
- [x] Added release note entry? (  docs/release-notes.md )
- [x] Tested? 