### PR TITLE
For DNS provider TransIP add IPv6 and pd_public_ipv6 was not calculat…

### DIFF
--- a/ansible/roles/openshift-4-cluster/tasks/destroy-network.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/destroy-network.yml
@@ -5,7 +5,8 @@
     tasks_from: destroy.yml
   vars:
     pd_provider: "{{ dns_provider }}"
-    pd_public_ip: "{{ listen_address }}"
+    pd_public_ip: "{% if 'IPv4' in ip_families %}{{ public_ip | default(listen_address) }}{% endif %}"
+    pd_public_ipv6: "{% if 'IPv6' in ip_families %}{{ public_ipv6 | default(listen_address_ipv6) }}{% endif %}"
     pd_cloudflare_account_api_token: "{{ cloudflare_account_api_token }}"
     pd_cloudflare_zone: "{{ cloudflare_zone }}"
     pd_aws_access_key: "{{ aws_access_key }}"

--- a/ansible/roles/public_dns/tasks/create-transip.yml
+++ b/ansible/roles/public_dns/tasks/create-transip.yml
@@ -17,4 +17,27 @@
   - '*.apps'
   tags:
     - public_dns
+  when: (pd_public_ip is defined) and (pd_public_ip|length > 0)
+
+
+- name: Create IPv6 DNS record at TransIP
+  uri:
+    url: "https://api.transip.nl/v6/domains/{{ transip_zone }}/dns"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ transip_token }}"
+    body_format: json
+    body:
+      dnsEntry:
+        name: "{{ item }}.{{ cluster_name }}"
+        expire: 60
+        type: AAAA
+        content: "{{ pd_public_ipv6 }}"
+    status_code: 201
+  with_items:
+  - api
+  - '*.apps'
+  tags:
+    - public_dns
+  when: (pd_public_ipv6 is defined) and (pd_public_ipv6|length > 0)
 

--- a/ansible/roles/public_dns/tasks/destroy-transip.yml
+++ b/ansible/roles/public_dns/tasks/destroy-transip.yml
@@ -1,4 +1,4 @@
-- name: Create DNS record at TransIP
+- name: Delete DNS record at TransIP
   uri:
     url: "https://api.transip.nl/v6/domains/{{ transip_zone }}/dns"
     method: DELETE
@@ -17,4 +17,27 @@
   - '*.apps'
   tags:
     - public_dns
+  when: (pd_public_ip is defined) and (pd_public_ip | length > 0)
+
+- name: Delete IPv6 DNS record at TransIP
+  uri:
+    url: "https://api.transip.nl/v6/domains/{{ transip_zone }}/dns"
+    method: DELETE
+    headers:
+      Authorization: "Bearer {{ transip_token }}"
+    body_format: json
+    body:
+      dnsEntry:
+        name: "{{ item }}.{{ cluster_name }}"
+        expire: 60
+        type: AAAA
+        content: "{{ pd_public_ipv6 }}"
+    status_code: 204
+  with_items:
+  - api
+  - '*.apps'
+  tags:
+    - public_dns
+  when: (pd_public_ipv6 is defined) and (pd_public_ipv6|length > 0)
+
 


### PR DESCRIPTION
For DNS provider TransIP add IPv6 and pd_public_ipv6 was not calculated during destroy phase

## Description
- Enhanced dns provider TransIP with create and destroy of ipv6 address
- During destroy phase of 99-cluster.yml the pd_public_ip and pd_public_ipv6 were fixed instead of calculate. 

## Checklist/ToDo's

- [ ] Added documentation?
- [ ] Added release note entry? (  docs/release-notes.md )
- [X] Tested? 