### PR TITLE
Updating Hetzner server creation

### DIFF
--- a/ansible/00-provision-hetzner.yml
+++ b/ansible/00-provision-hetzner.yml
@@ -10,7 +10,7 @@
   tasks:
   - name: Add hetzner server to inventory
     add_host: 
-      name: "{{ hetzner_hostname }}"
+      name: "{{ hetzner_ip }}"
 
 - name: install hetzner server
   hosts: all
@@ -24,4 +24,3 @@
       name: provision-hetzner
     tags:
       - provision-hetzner
-

--- a/ansible/roles/provision-hetzner/defaults/main.yml
+++ b/ansible/roles/provision-hetzner/defaults/main.yml
@@ -1,10 +1,11 @@
 ---
-hetzner_autosetup_file: autosetup
-hetzner_disk1: nvme0n1
-hetzner_disk2: nvme1n1
-hetzner_image: "/root/.oldroot/nfs/install/../images/CentOS-82-64-minimal.tar.gz"
+hetzner_webservice_username: # see Hetzner Robot -> Settings -> Webservice
+hetzner_webservice_password:
+hetzner_hostname: # needed for Hetzner server computer name
+hetzner_ip: # needed for Hetzner Web UI and Ansible
+hetzner_autosetup_file: templates/autosetup
+hetzner_disk1: sda
+hetzner_disk2: sdb
+hetzner_image: "/root/.oldroot/nfs/install/../images/CentOS-84-64-minimal.tar.gz"
 hetzner_image_ignore_errors: false
-# hetzner_webservice_username:
-# hetzner_webservice_password:
-# hetzner_hostname: "hostname.example.com"
-
+ansible_python_interpreter: /usr/bin/python3 # target host python interpreter

--- a/docs/hetzner.md
+++ b/docs/hetzner.md
@@ -123,19 +123,22 @@ You are now ready to reboot your system into the newly installed OS.
 
 If you do not want to do the above steps by hand: use Ansible! :-)
 
-1) Create `cluster.yml` with some hetzner specific options:
+1) Create a `cluster.yml` in the repo's root folder and add your Hetzner server specifc information, as in the following example:
     ```
-    # Hetzner informations (for role provision-hetzner)
-    hetzner_hostname: "hostname.domain.tld"
-    hetzner_webservice_username: "xxxx"
-    hetzner_webservice_password: "xxxx"
-    hetzner_ip: "xxx.xxx.xxx.xxx"
-    hetzner_disk1: nvme0n1
-    hetzner_disk1: nvme1n1
-
-    # Optional:
-    #   hetzner_image: "/root/.oldroot/nfs/install/../images/CentOS-75-64-minimal.tar.gz"
-    #   hetzner_autosetup_file: "{{ playbook_dir }}/my-autosetup-for-openshift"
+   hetzner_webservice_username: "USERNAME"
+   hetzner_webservice_password: "PASSWORD"
+   hetzner_hostname: "HOSTNAME"
+   hetzner_ip: "IP_ADDRESS"
     ```
 
-2) Run playbook: `./ansible/00-provision-hetzner.yml`
+   More detailed information about the configurable parameters can be found in the [defaults variable file](../ansible/roles/provision-hetzner/defaults/main.yml)
+
+2) Run playbook: `ansible/00-provision-hetzner.yml`
+
+   Assuming you protected the SSH private key for logging into your Hetzner server with a password, you should use the ssh-agent for calling the Ansible playbook, so that the password for the SSH key is requested once and then stored for the entire session (so that you don't need to enter your password multiple times). The full playbook call from the repo's root folder (using the standard private SSH key name `id_rsa`) would then look like this:
+
+   ```
+   ssh-agent bash
+   ssh-add ~/.ssh/id_rsa
+   ansible-playbook ansible/00-provision-hetzner.yml
+   ```


### PR DESCRIPTION
- Updated to newest CentOS version 8.4.6.4 as default, which now also requires Python3 (thus the change in ansible_python_interpreter).
- Ansible using IP address (hetzner_ip) now instead of hostname (hetzner_hostname), cause the hetzner_hostname var is also used for Hetzner server name during installimage.
- Cleaned Hetzner provisioning role variables in defaults/main.yml.
- Added documentation about usage of password-protected private SSH keys.
