### PR TITLE
DigitalOcean DNs with Let's Encrypt Validation and subnet_ip var for load balancer

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/hetzner-ocp4.iml
+++ b/.idea/hetzner-ocp4.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/hetzner-ocp4.iml" filepath="$PROJECT_DIR$/.idea/hetzner-ocp4.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -99,11 +99,12 @@ We are now ready to install `libvirt` as our hypervisor, provision VMs and prepa
 
 Here is an example about [_cluster.yml_](cluster-example.yml) file that contains information about the cluster that is going to be installed.
 
-| variable | describtion  |
+| variable | description  |
 |---|---|
 |cluster_name  |Name of the cluster to be installed |
 |public_domain  |Root domain that will be used for your cluster.  |
 |ip_families|Decide whether you want IPv4, IPv6 or dual-stack, detault: "['IPv4']"|
+|subnet_ip| |Override for servers with one NIC and not being used as router (Typical home setup)|
 |public_ip  |Override for public ip entries. defaults to `hostvars['localhost']['ansible_default_ipv4']['address']`. |
 |public_ipv6  |Override for public ip entries. defaults to `hostvars['localhost']['ansible_default_ipv6']['address']`. |
 |dns_provider  |DNS provider, value can be _route53_, _cloudflare_, _gcp_, _azure_,_transip_ or _none_. Check __Setup public DNS records__ for more info. |

--- a/ansible/roles/letsencrypt/tasks/check-variables.yml
+++ b/ansible/roles/letsencrypt/tasks/check-variables.yml
@@ -65,6 +65,30 @@
     - le_hetzner_zone
   when: le_dns_provider == "hetzner"
 
+- name: Check required DigitalOcean variables
+  assert:
+    that:
+      - lookup('vars',item) is defined
+    msg: "{{ item }} is not defined!"
+  with_items:
+    - le_digitalocean_token
+    - le_digitalocean_zone
+  when: le_dns_provider == "digitalocean"
+
+- name: Debug var only with -vv DigitalOcean
+  debug:
+    msg: "{{ item }}={{ lookup('vars',item) }}"
+    verbosity: 2
+  with_items:
+    - le_letsencrypt_account_email
+    - le_digitalocean_token
+    - le_digitalocean_zone
+    - le_public_domain
+    - le_certificates_dir
+    - le_public_domain
+    - le_acme_directory
+  when: le_dns_provider == "digitalocean"
+
 - name: Debug var only with -vv CloudFlare
   debug:
     msg: "{{ item }}={{ lookup('vars',item) }}"

--- a/ansible/roles/letsencrypt/tasks/main.yml
+++ b/ansible/roles/letsencrypt/tasks/main.yml
@@ -249,18 +249,18 @@
   when: le_dns_provider == "azure" and sample_com_challenge is changed
 
 - name: Delete DNS record at DigitalOcean
-  uri:
-    url: "https://api.digitalocean.com/v2/domains/{{ digitalocean_zone }}/records"
-  method: DELETE
-  headers:
-    Authorization: "Bearer {{ digitalocean_token }}"
-  body_format: json
-  body:
-    dnsEntry:
-      name: "{{ item.0.key | replace( digitalocean_zone , '') | regex_replace('\\.$', '') }}"
-      expire: 60
-      type: TXT
-      content: "{{ item.1 }}"
+    uri:
+      url: "https://api.digitalocean.com/v2/domains/{{ digitalocean_zone }}/records"
+    method: DELETE
+    headers:
+      Authorization: "Bearer {{ digitalocean_token }}"
+    body_format: json
+    body:
+      dnsEntry:
+        name: "{{ item.0.key | replace( digitalocean_zone , '') | regex_replace('\\.$', '') }}"
+        expire: 60
+        type: TXT
+        content: "{{ item.1 }}"
     status_code: 204
   register: record
   loop: "{{ challenge_data_dns | default({}) | dict2items | subelements('value') }}"

--- a/ansible/roles/letsencrypt/tasks/main.yml
+++ b/ansible/roles/letsencrypt/tasks/main.yml
@@ -248,7 +248,7 @@
 
 - name: Delete DNS record at DigitalOcean
   uri:
-    url: "https://api.digitalocean.com/v2/domains/{{ digitalocean_zone }}/records"
+    url: "https://api.digitalocean.com/v2/domains/{{ digitalocean_zone }}/records/{{ item }}"
     method: DELETE
     headers:
       Authorization: "Bearer {{ digitalocean_token }}"
@@ -257,8 +257,7 @@
       name: "{{ item.0.key | replace( digitalocean_zone , '') | regex_replace('\\.$', '') }}"
       type: TXT
       data: "{{ item.1 }}"
-    status_code: 204
-  register: record
+    status_code: 200, 204
   loop: "{{ challenge_data_dns | default({}) | dict2items | subelements('value') }}"
   when: le_dns_provider == "digitalocean" and sample_com_challenge is changed
 

--- a/ansible/roles/letsencrypt/tasks/main.yml
+++ b/ansible/roles/letsencrypt/tasks/main.yml
@@ -137,7 +137,24 @@
   loop: "{{ challenge_data_dns | default({}) | dict2items | subelements('value') }}"
   when: le_dns_provider == "transip" and sample_com_challenge is changed
 
-
+- name: Create DNS record at DigitalOcean
+  digitalocean_dns:
+    uri:
+      url: "https://api.digitalocean.com/v2/domains/{{ digitalocean_zone }}/records"
+      method: POST
+      headers:
+        Authorization: "Bearer {{ digitalocean_token }}"
+      body_format: json
+      body:
+        dnsEntry:
+          name: "{{ item.0.key | replace( digitalocean_zone ,'') | regex_replace('\\.$', '') }}"
+          expire: 60
+          type: TXT
+          content: "{{ item.1 }}"
+    status_code: 201
+  register: record
+  loop: "{{ challenge_data_dns | default({}) | dict2items | subelements('value') }}"
+  when: le_dns_provider == "digitalocean" and sample_com_challenge is changed
 
 - name: DNS record info
   debug:
@@ -231,6 +248,25 @@
   register: record
   loop: "{{ challenge_data_dns | default({}) | dict2items | subelements('value') }}"
   when: le_dns_provider == "azure" and sample_com_challenge is changed
+
+- name: Delete DNS record at DigitalOcean
+  digitalocean_dns:
+    uri:
+      url: "https://api.digitalocean.com/v2/domains/{{ digitalocean_zone }}/records"
+    method: DELETE
+    headers:
+      Authorization: "Bearer {{ digitalocean_token }}"
+    body_format: json
+    body:
+      dnsEntry:
+        name: "{{ item.0.key | replace( digitalocean_zone , '') | regex_replace('\\.$', '') }}"
+        expire: 60
+        type: TXT
+        content: "{{ item.1 }}"
+    status_code: 204
+  register: record
+  loop: "{{ challenge_data_dns | default({}) | dict2items | subelements('value') }}"
+  when: le_dns_provider == "digitalocean" and sample_com_challenge is changed
 
 
 - name: Delete DNS record at TransIP

--- a/ansible/roles/letsencrypt/tasks/main.yml
+++ b/ansible/roles/letsencrypt/tasks/main.yml
@@ -146,9 +146,8 @@
     body_format: json
     body:
       name: "{{ item.0.key | replace( digitalocean_zone ,'') | regex_replace('\\.$', '') }}"
-      expire: 60
       type: TXT
-      content: "{{ item.1 }}"
+      data: "{{ item.1 }}"
     status_code: 201
   register: record
   loop: "{{ challenge_data_dns | default({}) | dict2items | subelements('value') }}"
@@ -256,9 +255,8 @@
     body_format: json
     body:
       name: "{{ item.0.key | replace( digitalocean_zone , '') | regex_replace('\\.$', '') }}"
-      expire: 60
       type: TXT
-      content: "{{ item.1 }}"
+      data: "{{ item.1 }}"
     status_code: 204
   register: record
   loop: "{{ challenge_data_dns | default({}) | dict2items | subelements('value') }}"

--- a/ansible/roles/letsencrypt/tasks/main.yml
+++ b/ansible/roles/letsencrypt/tasks/main.yml
@@ -138,19 +138,18 @@
   when: le_dns_provider == "transip" and sample_com_challenge is changed
 
 - name: Create DNS record at DigitalOcean
-  digitalocean_dns:
-    uri:
-      url: "https://api.digitalocean.com/v2/domains/{{ digitalocean_zone }}/records"
-      method: POST
-      headers:
-        Authorization: "Bearer {{ digitalocean_token }}"
-      body_format: json
-      body:
-        dnsEntry:
-          name: "{{ item.0.key | replace( digitalocean_zone ,'') | regex_replace('\\.$', '') }}"
-          expire: 60
-          type: TXT
-          content: "{{ item.1 }}"
+  uri:
+    url: "https://api.digitalocean.com/v2/domains/{{ digitalocean_zone }}/records"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ digitalocean_token }}"
+    body_format: json
+    body:
+      dnsEntry:
+        name: "{{ item.0.key | replace( digitalocean_zone ,'') | regex_replace('\\.$', '') }}"
+        expire: 60
+        type: TXT
+        content: "{{ item.1 }}"
     status_code: 201
   register: record
   loop: "{{ challenge_data_dns | default({}) | dict2items | subelements('value') }}"
@@ -250,19 +249,18 @@
   when: le_dns_provider == "azure" and sample_com_challenge is changed
 
 - name: Delete DNS record at DigitalOcean
-  digitalocean_dns:
-    uri:
-      url: "https://api.digitalocean.com/v2/domains/{{ digitalocean_zone }}/records"
-    method: DELETE
-    headers:
-      Authorization: "Bearer {{ digitalocean_token }}"
-    body_format: json
-    body:
-      dnsEntry:
-        name: "{{ item.0.key | replace( digitalocean_zone , '') | regex_replace('\\.$', '') }}"
-        expire: 60
-        type: TXT
-        content: "{{ item.1 }}"
+  uri:
+    url: "https://api.digitalocean.com/v2/domains/{{ digitalocean_zone }}/records"
+  method: DELETE
+  headers:
+    Authorization: "Bearer {{ digitalocean_token }}"
+  body_format: json
+  body:
+    dnsEntry:
+      name: "{{ item.0.key | replace( digitalocean_zone , '') | regex_replace('\\.$', '') }}"
+      expire: 60
+      type: TXT
+      content: "{{ item.1 }}"
     status_code: 204
   register: record
   loop: "{{ challenge_data_dns | default({}) | dict2items | subelements('value') }}"

--- a/ansible/roles/letsencrypt/tasks/main.yml
+++ b/ansible/roles/letsencrypt/tasks/main.yml
@@ -145,11 +145,10 @@
       Authorization: "Bearer {{ digitalocean_token }}"
     body_format: json
     body:
-      dnsEntry:
-        name: "{{ item.0.key | replace( digitalocean_zone ,'') | regex_replace('\\.$', '') }}"
-        expire: 60
-        type: TXT
-        content: "{{ item.1 }}"
+      name: "{{ item.0.key | replace( digitalocean_zone ,'') | regex_replace('\\.$', '') }}"
+      expire: 60
+      type: TXT
+      content: "{{ item.1 }}"
     status_code: 201
   register: record
   loop: "{{ challenge_data_dns | default({}) | dict2items | subelements('value') }}"
@@ -256,11 +255,10 @@
       Authorization: "Bearer {{ digitalocean_token }}"
     body_format: json
     body:
-      dnsEntry:
-        name: "{{ item.0.key | replace( digitalocean_zone , '') | regex_replace('\\.$', '') }}"
-        expire: 60
-        type: TXT
-        content: "{{ item.1 }}"
+      name: "{{ item.0.key | replace( digitalocean_zone , '') | regex_replace('\\.$', '') }}"
+      expire: 60
+      type: TXT
+      content: "{{ item.1 }}"
     status_code: 204
   register: record
   loop: "{{ challenge_data_dns | default({}) | dict2items | subelements('value') }}"

--- a/ansible/roles/letsencrypt/tasks/main.yml
+++ b/ansible/roles/letsencrypt/tasks/main.yml
@@ -249,8 +249,8 @@
   when: le_dns_provider == "azure" and sample_com_challenge is changed
 
 - name: Delete DNS record at DigitalOcean
-    uri:
-      url: "https://api.digitalocean.com/v2/domains/{{ digitalocean_zone }}/records"
+  uri:
+    url: "https://api.digitalocean.com/v2/domains/{{ digitalocean_zone }}/records"
     method: DELETE
     headers:
       Authorization: "Bearer {{ digitalocean_token }}"

--- a/ansible/roles/openshift-4-cluster/tasks/create-network.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/create-network.yml
@@ -15,7 +15,7 @@
   set_fact:
     vn_subnet_ipv6: "{{ hostvars['localhost']['ansible_default_ipv6']['address'].split(':')[:4] | join(':') | string}}:{{ '%x' % vn_subnet.split('.')[2] | int }}"
     ipv6_listen_public:
-      - "{{ public_ipv6 | default(listen_address_ipv6) }}"
+      - "{{ subnet_ipv6 | default(listen_address_ipv6) }}"
     ipv6_listen_private:
       - "{{ hostvars['localhost']['ansible_default_ipv6']['address'].split(':')[:4] | join(':') | string}}:{{ '%x' % vn_subnet.split('.')[2] | int }}::1"
   when: "'IPv6' in ip_families"
@@ -26,7 +26,7 @@
     ipv4_listen_private:
       - "{{ vn_subnet.split('.')[:3] | join('.')}}.1"
     ipv4_listen_public:
-      - "{{ public_ip | default(listen_address) }}"
+      - "{{ subnet_ip | default(listen_address) }}"
   when: "'IPv4' in ip_families"
 
 - name: Build list of nodes
@@ -139,6 +139,7 @@
     tasks_from: create.yml
   vars:
     pd_provider: "{{ dns_provider }}"
+    pd_subnet_ip: "{% if 'IPv4' in ip_families %}{{ subnet_ip | default(listen_address) }}{% endif %}"
     pd_public_ip: "{% if 'IPv4' in ip_families %}{{ public_ip | default(listen_address) }}{% endif %}"
     pd_public_ipv6: "{% if 'IPv6' in ip_families %}{{ public_ipv6 | default(listen_address_ipv6) }}{% endif %}"
     pd_cloudflare_account_api_token: "{{ cloudflare_account_api_token }}"
@@ -157,6 +158,6 @@
     path: /etc/hosts
     marker: "# {mark} ANSIBLE MANAGED BLOCK {{ cluster_name }}.{{ public_domain }}"
     block: |
-      {{ public_ip | default(listen_address) }} api.{{ cluster_name }}.{{ public_domain }}
+      {{ subnet_ip | default(listen_address) }} api.{{ cluster_name }}.{{ public_domain }}
   tags: public_dns
   when: dns_provider == 'none'

--- a/ansible/roles/openshift-4-cluster/tasks/create.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/create.yml
@@ -65,6 +65,9 @@
     le_hetzner_account_api_token: "{{ hetzner_account_api_token }}"
     le_hetzner_zone: "{{ hetzner_zone }}"
 
+    le_digitalocean_token: "{{ digitalocean_token }}"
+    le_digitalocean_zone: "{{ digitalocean_zone }}"
+
   tags: letsencrypt
   when: letsencrypt_disabled == false
 

--- a/ansible/roles/public_dns/tasks/create-digitalocean.yml
+++ b/ansible/roles/public_dns/tasks/create-digitalocean.yml
@@ -1,0 +1,17 @@
+- name: Create DNS record at DigitalOcean
+  uri:
+    url: "https://api.digitalocean.com/v2/domains/{{ digitalocean_zone }}/records"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ digitalocean_token }}"
+    body_format: json
+    body:
+      name: "{{ item }}.{{ cluster_name }}"
+      type: A
+      data: "{{ pd_public_ip }}"
+    status_code: 201
+  with_items:
+    - api
+    - '*.apps'
+  tags:
+    - public_dns

--- a/ansible/roles/public_dns/tasks/create-digitalocean.yml
+++ b/ansible/roles/public_dns/tasks/create-digitalocean.yml
@@ -15,3 +15,24 @@
     - '*.apps'
   tags:
     - public_dns
+  when: (pd_public_ip is defined) and (pd_public_ip|length > 0)
+
+
+- name: Create IPv6 DNS record at DigitalOcean
+  uri:
+    url: "https://api.digitalocean.com/v2/domains/{{ digitalocean_zone }}/records"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ digitalocean_token }}"
+    body_format: json
+    body:
+      name: "{{ item }}.{{ cluster_name }}"
+      type: AAAA
+      data: "{{ pd_public_ip }}"
+    status_code: 201
+  with_items:
+    - api
+    - '*.apps'
+  tags:
+    - public_dns
+  when: (pd_public_ipv6 is defined) and (pd_public_ipv6|length > 0)

--- a/ansible/roles/public_dns/tasks/destroy-digitalocean.yml
+++ b/ansible/roles/public_dns/tasks/destroy-digitalocean.yml
@@ -1,0 +1,26 @@
+---
+- name: Get all DNS records
+  uri:
+    url: "https://api.digitalocean.com/v2/domains/{{ digitalocean_zone }}/records"
+    headers:
+      Authorization: "Bearer {{ digitalocean_token }}"
+      Content-Type: 'application/json'
+    body_format: json
+    return_content: true
+  register: register_digitalocean_records
+  tags:
+    - public_dns
+
+- name: Define digitalocean_records_to_delete
+  set_fact:
+    digitalocean_records_to_delete: "{{register_digitalocean_records.json.domain_records | json_query('[?(data==`'~  pd_public_ip ~'` && ( name==`api.'~ cluster_name ~'` || name ==`*.apps.'~ cluster_name ~'` ) )] | [*].id') }}"
+
+- name: Delete DNS record at DigitalOcean
+  uri:
+    url: "https://dns.digitalocean.com/api/v1/records/{{ item }}"
+    url: "https://api.digitalocean.com/v2/domains/{{ digitalocean_zone }}/records/{{ item }}"
+    method: DELETE
+    headers:
+      Authorization: "Bearer {{ digitalocean_token }}"
+    status_code: 200, 204
+  with_items: "{{digitalocean_records_to_delete}}"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,11 @@
 # RELEASE NOTES
 
+## 2021-10-10
+
+ * Added DigitalOcean DNS
+ * Fixed some typos
+ * Added subnet_ip for deployments where LB IP and Public IP are different.
+
 ## 2021-04-09
 
  * Bump OpenShift Version to 4.7.0

--- a/pipeline/digitalocean-pipeline.yaml
+++ b/pipeline/digitalocean-pipeline.yaml
@@ -1,0 +1,62 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: hetzner-ocp4-digitalocean
+spec:
+  resources:
+    - name: workspace
+      type: git
+  tasks:
+    - name: reset-server
+      taskRef:
+        name: reset-hetzner-server
+      resources:
+        inputs:
+          - name: hetzner-ocp4
+            resource: workspace
+    - name: init-server
+      runAfter:
+        - reset-server
+      taskRef:
+        name: init-server
+      resources:
+        inputs:
+          - name: hetzner-ocp4
+            resource: workspace
+    - name: prepare-host
+      runAfter:
+        - init-server
+      taskRef:
+        name: prepare-host
+      resources:
+        inputs:
+          - name: hetzner-ocp4
+            resource: workspace
+    - name: create-cluster
+      runAfter:
+        - prepare-host
+      taskRef:
+        name: generic-playbook-runner
+      params:
+        - name: playbook
+          value: 02-create-cluster.yml
+        - name: cluster-yml
+          value: digitalocean-cluster.yml
+      resources:
+        inputs:
+          - name: hetzner-ocp4
+            resource: workspace
+    - name: destroy-cluster
+      runAfter:
+        - create-cluster
+      taskRef:
+        name: generic-playbook-runner
+      params:
+        - name: playbook
+          value: 99-destroy-cluster.yml
+        - name: cluster-yml
+          value: digitalocean-cluster.yml
+      resources:
+        inputs:
+          - name: hetzner-ocp4
+            resource: workspace


### PR DESCRIPTION
## Description
Based on the work from @soukron I expanded on the steps to create DigitalOcean at cluster creation, with DNS validation.

For those deploying on a server, other than Hetzner, I've also changed the name of the variable for creating the load balancer to subnet_ip.

## Checklist/ToDo's

- [ x] Added documentation?
- [ x] Added release note entry? (  docs/release-notes.md )
- [ x] Tested? 