### PR TITLE
Fix/qemu

### DIFF
--- a/ansible/roles/openshift-4-cluster/tasks/create-vm.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/create-vm.yml
@@ -3,7 +3,7 @@
 # # /var/lib/libvirt/images/rhcos42.qcow2
 # # /var/lib/libvirt/images/CentOS-7-x86_64-GenericCloud.qcow2
 - name: Create disk for {{ vm_instance_name }}
-  command: "qemu-img create -f qcow2 -b {{ coreos_image_location }} /var/lib/libvirt/images/{{ vm_instance_name }}.qcow2 {{ vm_root_disk_size }}"
+  command: "qemu-img create -f qcow2 -b {{ coreos_image_location }} -F qcow2 /var/lib/libvirt/images/{{ vm_instance_name }}.qcow2 {{ vm_root_disk_size }}"
   args:
     creates: "/var/lib/libvirt/images/{{ vm_instance_name }}.qcow2"
   when: vm_storage_backend == "qcow2"

--- a/docs/cnv.md
+++ b/docs/cnv.md
@@ -25,7 +25,7 @@ compute_special_cpu: "<cpu mode='host-passthrough'></cpu>"
 master_special_cpu: "<cpu mode='host-passthrough'></cpu>"
 ```
 
-If you want to install the Advanced Cluster Security for Kubernetes you must also set the cpu mode `host-passthrough`. Otherwise, with the default vm settings, the central container will start with the error that the SSE 4.2 instruction set is not available.
+If you want to use Advanced Cluster Security for Kubernetes you must also set the cpu mode `host-passthrough`. Otherwise, with the default vm settings, the central container will start with the error that the SSE 4.2 instruction set is not available.
 
 ## Install CNV via OperatorHub
 

--- a/docs/cnv.md
+++ b/docs/cnv.md
@@ -1,4 +1,4 @@
-# Container-native virtualization 
+# Container-native virtualization
 ## Check nested  virtualization at kvm-host (intel)
 
 ```
@@ -24,6 +24,8 @@ master_vcpu: 8
 compute_special_cpu: "<cpu mode='host-passthrough'></cpu>"
 master_special_cpu: "<cpu mode='host-passthrough'></cpu>"
 ```
+
+If you want to install the Advanced Cluster Security for Kubernetes you must also set the cpu mode `host-passthrough`. Otherwise, with the default vm settings, the central container will start with the error that the SSE 4.2 instruction set is not available.
 
 ## Install CNV via OperatorHub
 


### PR DESCRIPTION
## Description
Fixes qemu-img: Deprecate use of -b without -F. 
Without this fix task `Create disk for {{ vm_instance_name }}` fails with a message like 

```qemu-img: /var/lib/libvirt/images/[...]: Backing file specified without backing format\nDetected format of qcow2.```

## Checklist/ToDo's

- [ ] Added documentation?
- [ ] Added release note entry? (  docs/release-notes.md )
- [ ] Tested? 