### PR TITLE
Use relative DNS records for Gandi

### DIFF
--- a/ansible/roles/public_dns/tasks/create-gandi.yml
+++ b/ansible/roles/public_dns/tasks/create-gandi.yml
@@ -3,7 +3,7 @@
   community.general.gandi_livedns:
     state: present
     domain: "{{ pd_gandi_zone }}"
-    record: "{{ item }}.{{ pd_public_domain }}"
+    record: "{{ item }}.{{ cluster_name }}"
     type: A
     values:
       - "{{ pd_public_ip }}"
@@ -20,7 +20,7 @@
   community.general.gandi_livedns:
     state: present
     domain: "{{ pd_gandi_zone }}"
-    record: "{{ item }}.{{ pd_public_domain }}"
+    record: "{{ item }}.{{ cluster_name }}"
     type: AAAA
     values:
       - "{{ pd_public_ipv6 }}"

--- a/ansible/roles/public_dns/tasks/destroy-gandi.yml
+++ b/ansible/roles/public_dns/tasks/destroy-gandi.yml
@@ -3,7 +3,7 @@
   community.general.gandi_livedns:
     state: absent
     domain: "{{ pd_gandi_zone }}"
-    record: "{{ item }}.{{ pd_public_domain }}"
+    record: "{{ item }}.{{ cluster_name }}"
     type: A
     api_key: "{{ gandi_api_key }}"
   with_items:
@@ -17,7 +17,7 @@
   community.general.gandi_livedns:
     state: absent
     domain: "{{ pd_gandi_zone }}"
-    record: "{{ item }}.{{ pd_public_domain }}"
+    record: "{{ item }}.{{ cluster_name }}"
     type: AAAA
     api_key: "{{ gandi_api_key }}"
   with_items:


### PR DESCRIPTION
## Description

Fixes for Gandi DNS provider introduced by https://github.com/RedHat-EMEA-SSA-Team/hetzner-ocp4/pull/233.
I did use the relative name for DNS record in ```letsencrypt``` role but not in ```public_dns``` one. My tests were OK because of old records in my zone created manually :blush: 

## Checklist/ToDo's

- [x] Added documentation?
- [x] Added release note entry? (  docs/release-notes.md )
- [x] Tested? 