### PR TITLE
Opt-in oc-mirror download

### DIFF
--- a/ansible/roles/openshift-4-cluster/defaults/main.yml
+++ b/ansible/roles/openshift-4-cluster/defaults/main.yml
@@ -83,6 +83,8 @@ helm_cli_location: "{{ openshift_mirror }}/pub/openshift-v4/clients/helm/latest/
 
 butane_cli_location: "{{ openshift_mirror }}/pub/openshift-v4/clients/butane/latest/butane-amd64"
 
+# set to false if using OKD as it does not provide oc-mirror binary
+download_oc_mirror: true
 
 # NFS Storage
 #  storage_nfs do not support multi cluster support, it overwrites the

--- a/ansible/roles/openshift-4-cluster/tasks/download-openshift-artifacts.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/download-openshift-artifacts.yml
@@ -11,10 +11,14 @@
       - "{{ coreos_download_url }}"
       - "{{ tmp_openshift_install_download_url }}"
       - "{{ tmp_openshift_client_download_url }}"
-      - "{{ openshift_location }}/oc-mirror.tar.gz"
+      - "{{ (download_oc_mirror is true) | ternary('{{ openshift_location }}/oc-mirror.tar.gz', '') }}"
       - "{{ opm_download_url }}"
       - "{{ helm_cli_location }}"
       - "{{ butane_cli_location }}"
+
+- name: Filter check_urls
+  ansible.builtin.set_fact:
+    check_urls: "{{ check_urls|select|list }}"
 
 - name: Add coreos_csum_url to check_urls
   ansible.builtin.set_fact:
@@ -148,6 +152,7 @@
     exclude:
       - 'README.md'
     creates: "/opt/openshift-client-{{ openshift_version }}/oc-mirror"
+  when: download_oc_mirror is true
 
 - name: Download OPM (gz)
   ansible.builtin.unarchive:
@@ -188,6 +193,7 @@
     dest: "{{ item.key }}"
     state: link
     force: yes
+    follow: false
   with_dict:
     "/usr/local/bin/oc": "/opt/openshift-client-{{ openshift_version }}/oc"
     "/usr/local/bin/oc-mirror": "/opt/openshift-client-{{ openshift_version }}/oc-mirror"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,9 @@
 # RELEASE NOTES
 
+## Unreleased
+
+* Make oc-mirror binary an opt-in
+
 ## 2023-04-14
 
  * Bump OpenShift version to 4.12.10


### PR DESCRIPTION
## Description

As OKD does not provide oc-mirror binary and considering that this binary is not mandatory, let's make it an opt-in **enabled by default**.

## Checklist/ToDo's

- [x] Added documentation? 
- [x] Added release note entry? (  docs/release-notes.md )
- [x] Tested? 