### PR TITLE
Feature enable fips

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Please configure in `cluster.yml` all necessary credentials:
 |`sdn_plugin_name`|`OVNKubernetes`|This allows you to change SDN plugin. Valid values are OpenShiftSDN and OVNKubernetes. (Default is OVNKubernetes.)
 |`masters_schedulable`|true|Set to false if don't want to allow workload onto the master nodes. (Default is to allow this)|
 |`install_config_capabilities`|null|Configure [Cluster capabilities](https://docs.openshift.com/container-platform/latest/post_installation_configuration/cluster-capabilities.html)
+|`fips`|false|Enable FIPS mode on the OpenShift cluster (Default is false)|
 
 ## Prepare kvm-host and install OpenShift
 

--- a/ansible/roles/openshift-4-cluster/defaults/main.yml
+++ b/ansible/roles/openshift-4-cluster/defaults/main.yml
@@ -37,6 +37,8 @@ compute_memory_unit: 'MiB'
 #   You may use k, M, G, T, P or E suffixe
 compute_root_disk_size: '120G'
 
+fips: false
+
 vm_autostart: false
 
 # Important: OpenShift version must match to RHEL CoreOS version!

--- a/ansible/roles/openshift-4-cluster/templates/install-config.yaml.j2
+++ b/ansible/roles/openshift-4-cluster/templates/install-config.yaml.j2
@@ -37,6 +37,7 @@ networking:
   type: {{ sdn_plugin_name }}
 platform:
   none: {}
+fips: {{ fips }}
 pullSecret:
   '{{ image_pull_secret }}'
 sshKey: |

--- a/cluster-example.yml
+++ b/cluster-example.yml
@@ -7,6 +7,7 @@ ip_families:
   - IPv4
   - IPv6
 
+fips: false
 # set custom public ip for DNS entries. Defaults to: hostvars['localhost']['ansible_default_ipv4']['address']
 # public_ip: 92.100.42.2
 dns_provider: [route53|cloudflare|gcp|azure|hetzner]

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,4 +1,6 @@
 # RELEASE NOTES
+## 2023-05-13
+ * Added new option `fips` to allow FIPS enabled cluster setups
 
 ## 2023-04-14
 


### PR DESCRIPTION
## Description

The installation of FIPS enabled cluster is currently not possible by using this play.
The added feature option `fips` (boolean|defaults to false) adds the required changes to the `install-config.yml`
and therefore allows FIPS clusters to be installed.

## Checklist/ToDo's

- [X] Added documentation?
- [X] Added release note entry? (  docs/release-notes.md )
- [X] Tested? 