### PR TITLE
Feature: add `ipsec` as new option to enable IPSec network

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ Please configure in `cluster.yml` all necessary credentials:
 |`sdn_plugin_name`|`OVNKubernetes`|This allows you to change SDN plugin. Valid values are OpenShiftSDN and OVNKubernetes. (Default is OVNKubernetes.)
 |`masters_schedulable`|true|Set to false if don't want to allow workload onto the master nodes. (Default is to allow this)|
 |`install_config_capabilities`|null|Configure [Cluster capabilities](https://docs.openshift.com/container-platform/latest/post_installation_configuration/cluster-capabilities.html)
+|`ipsec`|false|Enable IPSec communication between nodes when using `OVNKubernetes`|
+|`ipsec_only_on_day2`|false|Enable IPSec as a day2 operation (manual MTU adjustment required)|
+|`mtu`|1500|Configure MTU of default network (applies to SDN and OVN)|
 
 ## Prepare kvm-host and install OpenShift
 

--- a/ansible/roles/openshift-4-cluster/defaults/main.yml
+++ b/ansible/roles/openshift-4-cluster/defaults/main.yml
@@ -37,6 +37,9 @@ compute_memory_unit: 'MiB'
 #   You may use k, M, G, T, P or E suffixe
 compute_root_disk_size: '120G'
 
+ipsec: false
+network_mtu: 1500
+
 vm_autostart: false
 
 # Important: OpenShift version must match to RHEL CoreOS version!

--- a/ansible/roles/openshift-4-cluster/tasks/post-install.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/post-install.yml
@@ -68,6 +68,20 @@
   tags:
     - post-install
 
+- name: Ensure IPsec is enabled
+  # yamllint disable rule:line-length
+  # noqa var-spacing
+  ansible.builtin.command: "/opt/openshift-client-{{ openshift_version }}/oc patch networks.operator.openshift.io cluster --type merge --patch '{\"spec\": {\"defaultNetwork\": {\"ovnKubernetesConfig\": {\"ipsecConfig\": {} }}}}' --kubeconfig {{ openshift_install_dir }}/auth/kubeconfig"
+  # yamllint enable rule:line-length
+  register: ipsec_status
+  retries: 60
+  delay: 30
+  until: ipsec_status.rc == 0
+  when:
+    - ipsec is defined and ipsec
+    - ipsec_only_on_day2 is defined
+  tags: post-install
+
 ###########################################################################################
 # Install letsencrypt certificates
 ###########################################################################################

--- a/ansible/roles/openshift-4-cluster/templates/install-config.yaml.j2
+++ b/ansible/roles/openshift-4-cluster/templates/install-config.yaml.j2
@@ -35,6 +35,17 @@ networking:
   - fd00:172:16::/112
 {% endif %}
   type: {{ sdn_plugin_name }}
+{% if sdn_plugin_name == "OpenShiftSDN" %}
+  openshiftSDNConfig:
+    mtu: {{ network_mtu | int }}
+{% endif %}
+{% if sdn_plugin_name == "OVNKubernetes" and ( ipsec is defined and ipsec) %}
+  ovnKubernetesConfig:
+    mtu: {{ network_mtu - 50 | int }}
+{% if ipsec is defined and ipsec %}
+    ipsecConfig: {}
+{% endif %}
+{% endif %}
 platform:
   none: {}
 pullSecret:

--- a/cluster-example.yml
+++ b/cluster-example.yml
@@ -7,6 +7,9 @@ ip_families:
   - IPv4
   - IPv6
 
+ipsec: false
+ipsec_only_on_day2: false
+mtu: 1500
 # set custom public ip for DNS entries. Defaults to: hostvars['localhost']['ansible_default_ipv4']['address']
 # public_ip: 92.100.42.2
 dns_provider: [route53|cloudflare|gcp|azure|hetzner]

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,11 @@
 # RELEASE NOTES
 
+## 2023-05-13
+ * Added new option `ipsec` to enable IPSec when OVNKubernetes is used.
+ * Added new option `mtu` to allow customization of default network MTU.
+ * Added new option `ipsec_only_on_day2` to be prepared whenever the activation
+   of IPSec during installation is removed.
+
 ## 2023-04-14
 
  * Bump OpenShift version to 4.12.10


### PR DESCRIPTION
- Add new option `ipsec` to enable IPSec during installation. 
 - As OpenShift seem to make this a day2 operation, there is a additional option `ipsec_only_on_day2` which does the needed change after the installation. The user will have to make sure that the MTU is adjusted to handle the additonal 50 bytes of IPSec. The `ipsec` option already makes sure that the MTU (default 1500) is adjusted accordingly.
  - Due to this requirement the option `mtu` was introduced as well (defaults to 1500).

## Description


## Checklist/ToDo's

- [X] Added documentation?
- [X] Added release note entry? (  docs/release-notes.md )
- [X] Tested? 