### PR TITLE
Feature: add pre-checks to avoid failing at a later stage

### DIFF
--- a/ansible/02-create-cluster.yml
+++ b/ansible/02-create-cluster.yml
@@ -7,12 +7,31 @@
     - ../cluster.yml
 
   tasks:
-    - name: Check IPv6 & OpenShift version 4.12 or greater
+
+    - name: Check if `cluster_name` is configured
       ansible.builtin.fail:
-        msg: "Currently, it is not possible to install OpenShift 4.12 with IPv6 enabled with hetzner-ocp4 because of Issue #247"
-      when: (ip_families is defined and "IPv6" in ip_families) and (openshift_version is defined and openshift_version >= "4.12")
+        msg: "`cluster_name` is a mandatory setting, please define it in `cluster.yml`"
+      when: cluster_name is not defined
+
+    - name: Check if `dns_provider` is configured
+      ansible.builtin.fail:
+        msg: |-
+          `dns_provider` is a mandatory setting, please define it in `cluster.yml` with
+          one of the following values: route53, cloudflare, gcp, azure,transip, hetzner or none
+          Please check the README.md for most updated list.
+      when: dns_provider is not defined
+
+    - name: Check if `image_pull_secret` is configured
+      ansible.builtin.fail:
+        msg: "`image_pull_secret` is a mandatory setting, please define it in `cluster.yml`"
+      when: image_pull_secret is not defined and image_pull_secret | json_query('auths.quay\.io') | length == 0
+
+    - name: Check if `public_domain` is configured
+      ansible.builtin.fail:
+        msg: "`public_domain` is a mandatory setting, please define it in `cluster.yml`"
+      when: public_domain is not defined
 
     - name: Deploy cluster
-      import_role:
+      ansible.builtin.import_role:
         name: openshift-4-cluster
         tasks_from: create.yml

--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -1,3 +1,3 @@
 ---
-- import_playbook: 01-prepare-host.yml
-- import_playbook: 02-create-cluster.yml
+- ansible.builtin.import_playbook: 01-prepare-host.yml
+- ansible.builtin.import_playbook: 02-create-cluster.yml

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -10,7 +10,10 @@
   * Update proxy doc
   * [Add docs about how to change ssh port on rhel](docs/rhel-change-ssh-port.md) ( Issue #292 )
   * Update Hetzner Firewall documentation - added IPv6 ( Issue #291 )
-  
+  * Added pre-check routines to avoid failing at a later time
+   - all parameters which are required have to be provided, otherwise the playbook will fail early.
+  * Removed blocker for installation of OpenShift 4.12 with IPv6 enabled. Installation is now completing without issues.
+
 ## 2025-04-10
  * Fixed the issue that nfs storage creation did not work with CentOS 10
 


### PR DESCRIPTION
 - remove OpenShift 4.12 / IPv6 installation blocker (issue didn't show up during tests)
 - add `00-provision-hetzner.yml` to `setup.yml` as it doesn't do anything unless requested.
 - rename `import_playbook` to `ansible.builtin.import_playbook`.

## Description


## Checklist/ToDo's

- [X] Added documentation?
- [X] Added release note entry? (  docs/release-notes.md )
- [X] Tested? 