### PR TITLE
added OCP version check to check routine of #247

### DIFF
--- a/ansible/02-create-cluster.yml
+++ b/ansible/02-create-cluster.yml
@@ -7,10 +7,10 @@
     - ../cluster.yml
 
   tasks:
-    - name: Check IPv6 & OpenShift 4.12
+    - name: Check IPv6 & OpenShift version 4.12 or greater
       ansible.builtin.fail:
         msg: "Currently, it is not possible to install OpenShift 4.12 with IPv6 enabled with hetzner-ocp4 because of Issue #247"
-      when: (ip_families is defined and "IPv6" in ip_families)
+      when: (ip_families is defined and "IPv6" in ip_families) and (openshift_version is defined and openshift_version >= "4.12")
 
     - name: Deploy cluster
       import_role:


### PR DESCRIPTION
## Description
With this check, it's not possible to install an OCP cluster using IPv6, regardless which version is selected.

With this PR, an version_check is added to allow installations with OCP < 4.12 

```
TASK [Check IPv6 & OpenShift 4.12] *********************************************                                      
fatal: [host]: FAILED! => {"changed": false, "msg": "Currently, it is not possible to install OpenShift 4.12 with IPv6
 enabled with hetzner-ocp4 because of Issue #247"}      
```

## Checklist/ToDo's

- [ ] Added documentation?
- [ ] Added release note entry? (  docs/release-notes.md )
- [X] Tested? 