### PR TITLE
Advanced provisioning

### DIFF
--- a/ansible/roles/provision-hetzner/defaults/main.yml
+++ b/ansible/roles/provision-hetzner/defaults/main.yml
@@ -14,3 +14,4 @@ hetzner_size_of_libvirt_images: all
 
 robot_base: https://robot-ws.your-server.de/
 needs_reprovision: false
+already_in_rescue: false

--- a/ansible/roles/provision-hetzner/defaults/main.yml
+++ b/ansible/roles/provision-hetzner/defaults/main.yml
@@ -6,6 +6,8 @@ hetzner_ip:                     # needed for Hetzner Web UI and Ansible
 hetzner_autosetup_file: templates/autosetup
 hetzner_disk1: sda
 hetzner_disk2: sdb
+hetzner_raid_level: 0
+hetzner_vg_name: vg0
 hetzner_image: "/root/.oldroot/nfs/install/../images/CentOS-90-stream-amd64-base.tar.gz"
 hetzner_image_ignore_errors: false
 hetzner_size_of_libvirt_images: all

--- a/ansible/roles/provision-hetzner/tasks/provision-server.yml
+++ b/ansible/roles/provision-hetzner/tasks/provision-server.yml
@@ -89,7 +89,9 @@
       Content_Type: "application/x-www-form-urlencoded"
   register: activated
   delegate_to: localhost
-  when: not rescue.json.rescue.active
+  when:
+    - not rescue.json.rescue.active
+    - not already_in_rescue
 
 # - debug: msg="{{ activated }}"
 
@@ -109,6 +111,9 @@
       Content-Type: "application/x-www-form-urlencoded"
   register: reset
   delegate_to: localhost
+  when:
+    - not already_in_rescue
+
 
 - name: Remove server from local known_hosts file
   command: "/usr/bin/ssh-keygen -R {{ hetzner_ip }}"

--- a/ansible/roles/provision-hetzner/templates/autosetup
+++ b/ansible/roles/provision-hetzner/templates/autosetup
@@ -1,16 +1,16 @@
 DRIVE1 /dev/{{ hetzner_disk1 }}
 DRIVE2 /dev/{{ hetzner_disk2 }}
 SWRAID 1
-SWRAIDLEVEL 0
+SWRAIDLEVEL {{ hetzner_raid_level }}
 BOOTLOADER grub
 HOSTNAME {{ hetzner_hostname }}
 PART /boot ext3 1024M
-PART lvm vg0 all
+PART lvm {{ hetzner_vg_name }} all
 
-LV vg0 root / xfs 50G
-LV vg0 swap swap swap 8G
-LV vg0 home   /home   xfs      10G
-LV vg0 var    /var xfs 50G
-LV vg0 libvirt /var/lib/libvirt/images xfs {{ hetzner_size_of_libvirt_images }}
+LV {{ hetzner_vg_name }} root / xfs 50G
+LV {{ hetzner_vg_name }} swap swap swap 8G
+LV {{ hetzner_vg_name }} home   /home   xfs      10G
+LV {{ hetzner_vg_name }} var    /var xfs 50G
+LV {{ hetzner_vg_name }} libvirt /var/lib/libvirt/images xfs {{ hetzner_size_of_libvirt_images }}
 
 IMAGE {{ hetzner_image }}

--- a/cluster-example.yml
+++ b/cluster-example.yml
@@ -1,4 +1,10 @@
 ---
+hetzner_webservice_username: # see docs
+hetzner_webservice_password: # see docs
+
+hetzner_hostname: "changeme"
+hetzner_ip: "changeme"
+
 cluster_name: ocp4
 public_domain: example.com
 


### PR DESCRIPTION
## Description

This PR are some minor advancements that helped me provision my hetzner server or things I stumbled over, when I tried it first time.
1) Allow to skip the boot into rescue machine, if you are already booted into rescue system and want to work from there. Helpful if you're trying to debug stuff and are running the playbook often. Just set `already_in_rescue=yes`
2) allow to set raid level for data device. Nowadays there are 4TB SSDs available. I don't need a Raid0 on that, and prefer Raid1
3) Allow to rename the volume group
4) add the neccessary fields to get startet to the `cluster-example.yaml`
