### PR TITLE
Change Python install Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ dnf install -y ansible-navigator git podman
 Ansible navigator installation based on the upstream [documentation](https://ansible-navigator.readthedocs.io/en/latest/installation/#install-ansible-navigator).
 
 ```bash
-dnf install -y python38-pip podman git
+dnf install -y python3-pip podman git
 python3 -m pip install ansible-navigator --user
 echo 'export PATH=$HOME/.local/bin:$PATH' >> ~/.profile
 source ~/.profile


### PR DESCRIPTION
It need to be python3 to install python and pip

## Description
Documentation change

## Checklist/ToDo's

- [ ] Added documentation?
- [ ] Added release note entry? (  docs/release-notes.md )
- [ ] Tested? 