### PR TITLE
Add gandi to cluster-example.yml and docs #313

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Here is an example of a [cluster.yml](cluster-example.yml) file that contains in
 | variable | description  |Default|
 |---|---|---|
 |`cluster_name`               |Name of the cluster to be installed | **Required** |
-|`dns_provider`               |DNS provider, value can be _route53_, _cloudflare_, _gcp_, _azure_,_transip_, _hetzner_ or _none_. Check __Setup public DNS records__ for more info. | **Required** |
+|`dns_provider`               |DNS provider, value can be _route53_, _cloudflare_, _gcp_, _azure_,_transip_, _hetzner_, _gandi_ or _none_. Check __Setup public DNS records__ for more info. | **Required** |
 |`image_pull_secret`          |Token to be used to authenticate to the Red Hat image registry. You can download your pull secret from https://cloud.redhat.com/openshift/install/metal/user-provisioned | **Required** |
 |`letsencrypt_account_email`  |Email address that is used to create LetsEncrypt certs. If _cloudflare_account_email_ is not present for CloudFlare DNS records, _letsencrypt_account_email_ is also used with CloudFlare DNS account email |  **Required** |
 |`public_domain`              |Root domain that will be used for your cluster.  | **Required** |

--- a/ansible/roles/letsencrypt/README.md
+++ b/ansible/roles/letsencrypt/README.md
@@ -14,7 +14,7 @@ Role Variables
 
 | variable | describtion  | example | default | 
 |---|---|---|---|
-| le_dns_provider | DNS provider | `[route53|cloudflare|gcp|azure|hetzner]` |  non **required** |
+| le_dns_provider | DNS provider | `[route53\|cloudflare\|gcp\|azure\|hetzner\|gandi]` |  non **required** |
 | le_cloudflare_account_email | Cloudflare Account E-Mail for API authentication | `account@domain.tld`| non **required if provider is cloudflare** |
 | le_cloudflare_account_api_token | Cloudflare API token for API authentication | `loo...ngiJ`| non **required if provider is cloudflare** |
 | le_cloudflare_zone | Cloudflare zone in which the entries are created and deleted for the dns challenge | `domain.tld` | non **required if provider is cloudflare** |

--- a/cluster-example.yml
+++ b/cluster-example.yml
@@ -10,7 +10,7 @@ ip_families:
 fips: false
 # set custom public ip for DNS entries. Defaults to: hostvars['localhost']['ansible_default_ipv4']['address']
 # public_ip: 92.100.42.2
-dns_provider: [route53|cloudflare|gcp|azure|hetzner]
+dns_provider: [route53|cloudflare|gcp|azure|hetzner|gandi]
 letsencrypt_account_email: name@example.com
 # Depending on the dns provider:
 # CloudFlare

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,8 @@
 # RELEASE NOTES
 
+## 2024-06-15
+ * Added gandi as option to docs and example_cluster.yml
+
 ## 2023-12-27
  * Bump OpenShift version to 4.14.6
  * Improve & Fix ( #294 ) air-gapped documentation


### PR DESCRIPTION
## Description
Solving issue #313 by adding gandi to the options and docs.
It also solves a markdown rendering issue in the letsencrypt role README.md.

## Checklist/ToDo's

- [x] Added documentation?
- [x] Added release note entry? (  docs/release-notes.md )
- [x] Tested? (only docs / grammer)
  - It's only docs. I wasn't able to actually test the gandi integration.