### PR TITLE
Update EE-Image and Build Process

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,9 @@ In our setup, this will be `ansible/group_vars` and `ansible/host_vars`.
 ## Build ansible execution enviorment
 
 ```bash
+python -m venv ansible-builder
+source ./ansible-builder/bin/activate
+pip install ansible-builder>=3.1.0
 
 VERSION=$(date +%Y%m%d%H%M)
 

--- a/ansible-navigator.yaml
+++ b/ansible-navigator.yaml
@@ -3,7 +3,7 @@ ansible-navigator:
   execution-environment:
     container-options:
       - --net=host
-    image: quay.io/redhat-emea-ssa-team/hetzner-ocp4-ansible-ee:202304141355
+    image: quay.io/redhat-emea-ssa-team/hetzner-ocp4-ansible-ee:202503130905
   logging:
     level: info
   mode: stdout

--- a/ansible-navigator.yaml
+++ b/ansible-navigator.yaml
@@ -3,7 +3,7 @@ ansible-navigator:
   execution-environment:
     container-options:
       - --net=host
-    image: quay.io/redhat-emea-ssa-team/hetzner-ocp4-ansible-ee:202503130905
+    image: quay.io/redhat-emea-ssa-team/hetzner-ocp4-ansible-ee:202503131213
   logging:
     level: info
   mode: stdout

--- a/ansible/add-on-roles/garbagecollection/defaults/main.yml
+++ b/ansible/add-on-roles/garbagecollection/defaults/main.yml
@@ -1,3 +1,3 @@
 garbagecollection_high_treshold_percent: 66
 garbagecollection_low_treshold_percent: 50
-garbagecollection_minimum_age: "5m30s"
+garbagecollection_minimum_age: "6m"

--- a/ansible/roles/openshift-4-cluster/tasks/create-vm.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/create-vm.yml
@@ -15,7 +15,7 @@
   when: vm_storage_backend == "lvm"
 
 - name: Create logical volume
-  community.general.system.lvol:
+  community.general.lvol:
     vg: "{{ vm_storage_backend_location }}"
     lv: "{{ vm_instance_name }}"
     state: present

--- a/ansible/roles/openshift-4-cluster/tasks/create.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/create.yml
@@ -137,6 +137,6 @@
 
 - name: Include post installation tasks
   ansible.builtin.include_tasks: post-install.yml
-  tags:
+  tags: 
     - post-install
     - post-install-add-ons

--- a/ansible/roles/openshift-4-cluster/tasks/destroy-vm.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/destroy-vm.yml
@@ -13,7 +13,7 @@
   ignore_errors: yes
 
 - name: Delete logical volume
-  community.general.system.lvol:
+  community.general.lvol:
     vg: "{{ vm_storage_backend_location }}"
     lv: "{{ vm_instance_name }}"
     state: absent

--- a/ee-bindep.txt
+++ b/ee-bindep.txt
@@ -1,6 +1,11 @@
-pkgconf-pkg-config
+# for python-libvirt
 libvirt-client
 libvirt-libs
+pkgconf-pkg-config
 libvirt-devel
 gcc
-python38-devel
+python3.9-devel
+python3.11-devel
+python-devel
+# for postinstall commands
+python3-pip

--- a/ee-python-requirements.txt
+++ b/ee-python-requirements.txt
@@ -1,4 +1,5 @@
 libvirt-python
+jmespath
 # Azure should be covert by collection: community.azure
 # packaging
 # msrest

--- a/ee-requirements.yml
+++ b/ee-requirements.yml
@@ -1,8 +1,6 @@
 ---
 collections:
-  - name: https://github.com/ansible-collections/community.libvirt
-    type: git
-    version: main
+  - community.libvirt
   - community.crypto
   - community.general
   - community.aws

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -13,7 +13,7 @@ images:
 
 dependencies:
   ansible_core:
-    package_pip: ansible-core==2.14.4
+    package_pip: ansible-core==2.15.13
   ansible_runner:
     package_pip: ansible-runner
   galaxy: ee-requirements.yml

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -1,25 +1,34 @@
 ---
-version: 1
-
-# build_arg_defaults:
-  # EE_BASE_IMAGE: 'quay.io/ansible/ansible-runner:latest'
-
+version: 3
+  #build_arg_defaults:
+  # EE_BASE_IMAGE: 'quay.io/ansible/creator-ee:latest'
+  # EE_BASE_IMAGE: 'registry.redhat.io/ansible-automation-platform-25/ee-minimal-rhel9:1.0.0-832'
+  # EE_BASE_IMAGE: 'registry.redhat.io/ansible-automation-platform-25/ee-supported-rhel9:1.0.0-919'
+  # EE_BUILDER_IMAGE: 'registry.redhat.io/ansible-automation-platform/ansible-builder-rhel9:3.0.1-120'
 # ansible_config: 'ansible.cfg'
 
+images:
+  base_image:
+    name: docker.io/redhat/ubi9:latest
+
 dependencies:
+  ansible_core:
+    package_pip: ansible-core==2.14.4
+  ansible_runner:
+    package_pip: ansible-runner
   galaxy: ee-requirements.yml
   python: ee-python-requirements.txt
   system: ee-bindep.txt
 
 additional_build_steps:
-#   prepend: |
-#     RUN whoami
-#     RUN cat /etc/os-release
-  append:
+  prepend_builder:
+    - ENV PKGMGR_OPTS="--nodocs --setopt=install_weak_deps=0 --setopt=codeready-builder-for-rhel-9-x86_64-rpms.enabled=true --setopt=rhocp-4.18-for-rhel-9-x86_64-rpms.enabled=true"
+  prepend_final:
+    - ENV PKGMGR_OPTS="--nodocs --setopt=install_weak_deps=0 --setopt=codeready-builder-for-rhel-9-x86_64-rpms.enabled=true --setopt=rhocp-4.18-for-rhel-9-x86_64-rpms.enabled=true"
+    
+  append_final:
     # Upgrade pyopenssl to solve
     # The error was: AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'
     - RUN pip install pyopenssl --upgrade
-#     - RUN echo This is a post-install command!
-#     - RUN ls -la /etc
     # Needed for tekton
     - RUN pip install pre-commit


### PR DESCRIPTION
## Description
I updated the build information utilizing ansible-builder 3.1.0 and the v3 specification. Reason was, that the old images / modules caused errors on my cloudflare dns server. During the build process I faced several issues due to the newer modules which are fixed in this PR, too.

The image is already uploaded to quay

build and testing was done on a hetzner RHEL9 box with a 3x3 Cluster and cloudflare dns. other dns providers might have issues I couldnt discover.

the ansible-navigator version on the host MUST be higher than 3.3.1 as there was a bug in ansible-navigator with v:3 ansible-builder build images.

## Checklist/ToDo's

- [x] Added documentation?
- [ ] Added release note entry? (  docs/release-notes.md )
- [X] Tested? 