### PR TITLE
Fix version check by replacing a string comparison with and integer comparison

### DIFF
--- a/ansible/roles/openshift-4-cluster/tasks/post-install-storage-nfs.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/post-install-storage-nfs.yml
@@ -9,7 +9,7 @@
   ansible.builtin.package:
     name: nfs-utils
     state: present
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version >= '8'
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 8
 
 - name: Ensure NFS server is installed.
   ansible.builtin.package:
@@ -27,7 +27,7 @@
 - name: Set nfs_server
   ansible.builtin.set_fact:
     nfs_server: "nfs-server"
-  when: (ansible_os_family == "RedHat" and ansible_distribution_major_version >= '8') or (ansible_os_family == "Debian")
+  when: (ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 8) or (ansible_os_family == "Debian")
 
 - name: Ensure nfs is running.
   ansible.builtin.service:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,8 @@
 # RELEASE NOTES
 
+## 2025-04-10
+ * Fixed the issue that nfs storage creation did not work with CentOS 10
+
 ## 2025-04-04
  * Add support for CentOS 10
  * Use latest version of hetzner-ocp4-ansible-ee


### PR DESCRIPTION
## Description

Fixed the issue that nfs storage creation did not work with CentOS 10

## Checklist/ToDo's

- [X] Added release note entry? (  docs/release-notes.md )
- [x] Tested? 