### PR TITLE
devel branch - README changed to address AAP 2.5 repo issue for RHEL9

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ subscription-manager repos \
     --enable=rhel-9-for-x86_64-baseos-rpms \
     --enable=rhel-9-for-x86_64-appstream-rpms \
     --enable=rhel-9-for-x86_64-highavailability-rpms \
-    --enable=ansible-automation-platform-2.3-for-rhel-9-x86_64-rpms
+    --enable=ansible-automation-platform-2.5-for-rhel-9-x86_64-rpms
 ```
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ source ~/.profile
 ## Initialize tools
 
 ```
-ssh-keygen
+ssh-keygen -t rsa -b 4096
 cat ~/.ssh/*.pub >> ~/.ssh/authorized_keys
 ```
 


### PR DESCRIPTION
## Description

As the RHEL9 base works well with AAP 2.5 now - I updated the README in order to enable the aap 2.5 repo for RHEL9
A new installation of a cluster was tested on a RHEL9 base OS on the Hetzner enviornment

## Checklist/ToDo's

- [ x ] Added documentation?
- [ ] Added release note entry? (  docs/release-notes.md )
- [ x ] Tested? 