### PR TITLE
Release 2026-05-29

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Please configure in `cluster.yml` all necessary credentials:
 |DigitalOcean|`digitalocean_token: e7a6f82c3245b65cf4.....` <br>  `digitalocean_zone: domain.tld`|
 |Gandi|`gandi_account_api_token: 0123456...` <br>  `gandi_zone: domain.tld`|
 |GCP|`gcp_project: project-name `<br/>`gcp_managed_zone_name: 'zone-name'`<br/>`gcp_managed_zone_domain: 'example.com.'`<br/>`gcp_serviceaccount_file: ../gcp_service_account.json` |
-|Hetzner|`hetzner_account_api_token: 93543ade82AA$73.....` (legacy DNS) or <br>`hetzner_cloud_api_token: 93543ade82AA$73.....` (Hetzner Console DNS) <br>  `hetzner_zone: domain.tld`|
+|Hetzner|`hetzner_account_api_token: 93543ade82AA$73.....` (legacy DNS) or <br>`hetzner_cloud_api_token: 93543ade82AA$73.....` [(Hetzner Console DNS)](https://docs.hetzner.com/networking/dns/faq/beta) <br>  `hetzner_zone: domain.tld`|
 |Route53 / AWS|`aws_access_key: key` <br/>`aws_secret_key: secret` <br/>`aws_zone: domain.tld` <br/>|
 |TransIP|`transip_token: eyJ0eXAiOiJKV....` <br> `transip_zone: domain.tld`|
 |none|With `dns_provider: none` the playbooks will not create public dns entries. (It will skip letsencrypt too) Please create public dns entries if you want to access your cluster.|

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Please configure in `cluster.yml` all necessary credentials:
 |DigitalOcean|`digitalocean_token: e7a6f82c3245b65cf4.....` <br>  `digitalocean_zone: domain.tld`|
 |Gandi|`gandi_account_api_token: 0123456...` <br>  `gandi_zone: domain.tld`|
 |GCP|`gcp_project: project-name `<br/>`gcp_managed_zone_name: 'zone-name'`<br/>`gcp_managed_zone_domain: 'example.com.'`<br/>`gcp_serviceaccount_file: ../gcp_service_account.json` |
-|Hetzner|`hetzner_account_api_token: 93543ade82AA$73.....` <br>  `hetzner_zone: domain.tld`|
+|Hetzner|`hetzner_account_api_token: 93543ade82AA$73.....` or <br>`hetzner_cloud_api_token: 93543ade82AA$73.....`  <br>  `hetzner_zone: domain.tld`|
 |Route53 / AWS|`aws_access_key: key` <br/>`aws_secret_key: secret` <br/>`aws_zone: domain.tld` <br/>|
 |TransIP|`transip_token: eyJ0eXAiOiJKV....` <br> `transip_zone: domain.tld`|
 |none|With `dns_provider: none` the playbooks will not create public dns entries. (It will skip letsencrypt too) Please create public dns entries if you want to access your cluster.|

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Please configure in `cluster.yml` all necessary credentials:
 |DigitalOcean|`digitalocean_token: e7a6f82c3245b65cf4.....` <br>  `digitalocean_zone: domain.tld`|
 |Gandi|`gandi_account_api_token: 0123456...` <br>  `gandi_zone: domain.tld`|
 |GCP|`gcp_project: project-name `<br/>`gcp_managed_zone_name: 'zone-name'`<br/>`gcp_managed_zone_domain: 'example.com.'`<br/>`gcp_serviceaccount_file: ../gcp_service_account.json` |
-|Hetzner|`hetzner_account_api_token: 93543ade82AA$73.....` or <br>`hetzner_cloud_api_token: 93543ade82AA$73.....`  <br>  `hetzner_zone: domain.tld`|
+|Hetzner|`hetzner_account_api_token: 93543ade82AA$73.....` (legacy DNS) or <br>`hetzner_cloud_api_token: 93543ade82AA$73.....` (Hetzner Console DNS) <br>  `hetzner_zone: domain.tld`|
 |Route53 / AWS|`aws_access_key: key` <br/>`aws_secret_key: secret` <br/>`aws_zone: domain.tld` <br/>|
 |TransIP|`transip_token: eyJ0eXAiOiJKV....` <br> `transip_zone: domain.tld`|
 |none|With `dns_provider: none` the playbooks will not create public dns entries. (It will skip letsencrypt too) Please create public dns entries if you want to access your cluster.|

--- a/ansible-navigator.yaml
+++ b/ansible-navigator.yaml
@@ -3,7 +3,7 @@ ansible-navigator:
   execution-environment:
     container-options:
       - --net=host
-    image: quay.io/redhat-emea-ssa-team/hetzner-ocp4-ansible-ee:202601022255
+    image: quay.io/redhat-emea-ssa-team/hetzner-ocp4-ansible-ee:202603301213
   logging:
     level: info
   mode: stdout

--- a/ansible/roles/letsencrypt/tasks/create-hetzner.yml
+++ b/ansible/roles/letsencrypt/tasks/create-hetzner.yml
@@ -7,6 +7,9 @@
     type: TXT
     ttl: 60
     value: "{{ item.1 }}"
-    hetzner_token: "{{ hetzner_account_api_token }}"
+    # Hetzner Cloud API (Hetzner Cloud Token)
+    hetzner_api_token: "{{ hetzner_cloud_api_token | default(omit) }}"
+    # Legacy  API (Legacy DNS Token)
+    hetzner_token: "{{ hetzner_account_api_token | default(omit) }}"
   register: hetzner_record
   loop: "{{ challenge_data_dns | default({}) | dict2items | subelements('value') }}"

--- a/ansible/roles/letsencrypt/tasks/destroy-hetzner.yml
+++ b/ansible/roles/letsencrypt/tasks/destroy-hetzner.yml
@@ -7,6 +7,9 @@
     type: TXT
     ttl: 60
     value: "{{ item.1 }}"
-    hetzner_token: "{{ hetzner_account_api_token }}"
+    # Hetzner Cloud API (Hetzner Cloud Token)
+    hetzner_api_token: "{{ hetzner_cloud_api_token | default(omit) }}"
+    # Legacy  API (Legacy DNS Token)
+    hetzner_token: "{{ hetzner_account_api_token | default(omit) }}"
   register: hetzner_record
   loop: "{{ challenge_data_dns | default({}) | dict2items | subelements('value') }}"

--- a/ansible/roles/openshift-4-cluster/tasks/certificate-renewal.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/certificate-renewal.yml
@@ -28,7 +28,7 @@
     le_gcp_managed_zone_name: "{{ gcp_managed_zone_name }}"
     le_gcp_managed_zone_domain: "{{ gcp_managed_zone_domain }}"
 
-    le_hetzner_account_api_token: "{{ hetzner_account_api_token }}"
+    le_hetzner_account_api_token: "{{ hetzner_cloud_api_token | default(hetzner_account_api_token) | default(omit) }}"
     le_hetzner_zone: "{{ hetzner_zone }}"
 
     le_gandi_api_key: "{{ gandi_api_key }}"

--- a/ansible/roles/openshift-4-cluster/tasks/create.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/create.yml
@@ -65,7 +65,7 @@
     le_azure_tenant: "{{ azure_tenant }}"
     le_azure_resource_group: "{{ azure_resource_group }}"
 
-    le_hetzner_account_api_token: "{{ hetzner_account_api_token }}"
+    le_hetzner_account_api_token: "{{ hetzner_cloud_api_token | default(hetzner_account_api_token) | default(omit) }}"
     le_hetzner_zone: "{{ hetzner_zone }}"
 
     le_digitalocean_token: "{{ digitalocean_token }}"

--- a/ansible/roles/openshift-4-cluster/tasks/destroy-network.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/destroy-network.yml
@@ -14,7 +14,7 @@
     pd_aws_access_key: "{{ aws_access_key }}"
     pd_aws_secret_key: "{{ aws_secret_key }}"
     pd_aws_zone: "{{ aws_zone }}"
-    pd_hetzner_account_api_token: "{{ hetzner_account_api_token }}"
+    pd_hetzner_account_api_token: "{{ hetzner_cloud_api_token | default(hetzner_account_api_token) | default(omit) }}"
     pd_hetzner_zone: "{{ hetzner_zone }}"
     pd_gandi_api_key: "{{ gandi_api_key }}"
     pd_gandi_zone: "{{ gandi_zone }}"

--- a/ansible/roles/openshift-4-cluster/tasks/download-openshift-artifacts.yml
+++ b/ansible/roles/openshift-4-cluster/tasks/download-openshift-artifacts.yml
@@ -49,7 +49,7 @@
 
 - name: Determine if OpenShift client version
   ansible.builtin.command:
-    cmd: "{{ temp_ocp_dir.path }}/oc version -o yaml"
+    cmd: "{{ temp_ocp_dir.path }}/oc version -o yaml --client=true"
   register: oc_version
 
 - name: Set detected OpenShift client version raw

--- a/ansible/roles/public_dns/tasks/create-hetzner.yml
+++ b/ansible/roles/public_dns/tasks/create-hetzner.yml
@@ -7,13 +7,16 @@
     type: A
     ttl: 120
     value: "{{ pd_public_ip }}"
-    hetzner_token: "{{ hetzner_account_api_token }}"
+    # Hetzner Cloud API (Hetzner Cloud Token)
+    hetzner_api_token: "{{ hetzner_cloud_api_token | default(omit) }}"
+    # Legacy  API (Legacy DNS Token)
+    hetzner_token: "{{ hetzner_account_api_token | default(omit) }}"
   with_items:
     - api
     - '*.apps'
   tags:
     - public_dns
-  when: (pd_public_ip is defined) and (pd_public_ip|length > 0)
+  when: pd_public_ip is defined and pd_public_ip is not none and pd_public_ip | length > 0
 
 - name: Create IPv6 DNS record at Hetzner
   community.dns.hetzner_dns_record:
@@ -23,10 +26,13 @@
     type: AAAA
     ttl: 120
     value: "{{ pd_public_ipv6 }}"
-    hetzner_token: "{{ hetzner_account_api_token }}"
+    # Hetzner Cloud API (Hetzner Cloud Token)
+    hetzner_api_token: "{{ hetzner_cloud_api_token | default(omit) }}"
+    # Legacy  API (Legacy DNS Token)
+    hetzner_token: "{{ hetzner_account_api_token | default(omit) }}"
   with_items:
     - api
     - '*.apps'
   tags:
     - public_dns
-  when: (pd_public_ipv6 is defined) and (pd_public_ipv6|length > 0)
+  when: pd_public_ipv6 is defined and pd_public_ipv6 is not none and pd_public_ipv6 | length > 0

--- a/ansible/roles/public_dns/tasks/destroy-hetzner.yml
+++ b/ansible/roles/public_dns/tasks/destroy-hetzner.yml
@@ -7,13 +7,16 @@
     type: A
     ttl: 120
     value: "{{ pd_public_ip }}"
-    hetzner_token: "{{ hetzner_account_api_token }}"
+    # Hetzner Cloud API (Hetzner Cloud Token)
+    hetzner_api_token: "{{ hetzner_cloud_api_token | default(omit) }}"
+    # Legacy  API (Legacy DNS Token)
+    hetzner_token: "{{ hetzner_account_api_token | default(omit) }}"
   with_items:
     - api
     - '*.apps'
   tags:
     - public_dns
-  when: (pd_public_ip is defined) and (pd_public_ip|length > 0)
+  when: pd_public_ip is defined and pd_public_ip is not none and pd_public_ip | length > 0
 
 - name: Delete IPv6 DNS record at Hetzner
   community.dns.hetzner_dns_record:
@@ -23,10 +26,13 @@
     type: AAAA
     ttl: 120
     value: "{{ pd_public_ipv6 }}"
-    hetzner_token: "{{ hetzner_account_api_token }}"
+    # Hetzner Cloud API (Hetzner Cloud Token)
+    hetzner_api_token: "{{ hetzner_cloud_api_token | default(omit) }}"
+    # Legacy  API (Legacy DNS Token)
+    hetzner_token: "{{ hetzner_account_api_token | default(omit) }}"
   with_items:
     - api
     - '*.apps'
   tags:
     - public_dns
-  when: (pd_public_ipv6 is defined) and (pd_public_ipv6|length > 0)
+  when: pd_public_ipv6 is defined and pd_public_ipv6 is not none and pd_public_ipv6 | length > 0

--- a/cluster-example.yml
+++ b/cluster-example.yml
@@ -43,7 +43,10 @@ azure_subscription_id: subscription_id
 azure_tenant: tenant_id
 azure_resource_group: dns_zone_resource_group
 # Hetzner
+# Use 'hetzner_account_api_token' for legacy DNS
 hetzner_account_api_token: 3543ade82AA$73.....
+# Use '' if you already migrated your DNS Zone to hetzner cloud
+hetzner_cloud_api_token: 3543ade82AA$73.....
 hetzner_zone: example.com
 # Gandi
 gandi_api_key: api_key

--- a/cluster-example.yml
+++ b/cluster-example.yml
@@ -45,7 +45,7 @@ azure_resource_group: dns_zone_resource_group
 # Hetzner
 # Use 'hetzner_account_api_token' for legacy DNS
 hetzner_account_api_token: 3543ade82AA$73.....
-# Use '' if you already migrated your DNS Zone to hetzner cloud
+# Use 'hetzner_cloud_api_token' if you already migrated your DNS Zone to hetzner cloud
 hetzner_cloud_api_token: 3543ade82AA$73.....
 hetzner_zone: example.com
 # Gandi

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,9 @@
 # RELEASE NOTES
 
+## 2026-XX-XX
+
+ * Fix issue #352 - Cluster creation fails when checking OpenShift version
+
 ## 2026-01-23
 
  * Add support for DNS provider deSEC

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,8 +1,13 @@
 # RELEASE NOTES
 
-## 2026-XX-XX
+## 2026-05-29
 
  * Fix issue #352 - Cluster creation fails when checking OpenShift version
+ * Add support for `integration of Hetzner DNS into the Hetzner Console`
+    * use `hetzner_cloud_api_token` instead of `hetzner_account_api_token` if you already migrated your DNS Zone to Hetzner Console
+    * use `hetzner_account_api_token` (as before) if you didn't migrate to Hetzner Console yet
+    * [Migration Process](https://docs.hetzner.com/networking/dns/migration-to-hetzner-console/process)
+    * [Migration FAQ / Timeline etc.](https://docs.hetzner.com/networking/dns/migration-to-hetzner-console/process)
 
 ## 2026-01-23
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,13 @@
 # RELEASE NOTES
 
+## 2026-03-30
+
+ * Add support for `integration of Hetzner DNS into the Hetzner Console`
+    * use `hetzner_cloud_api_token` instead of `hetzner_account_api_token` if you already migrated your DNS Zone to Hetzner Console
+    * use `hetzner_account_api_token` (as before) if you didn't migrate to Hetzner Console yet
+    * [Migration Process](https://docs.hetzner.com/networking/dns/migration-to-hetzner-console/process)
+    * [Migration FAQ / Timeline etc.](https://docs.hetzner.com/networking/dns/migration-to-hetzner-console/process)
+
 ## 2026-01-23
 
  * Add support for DNS provider deSEC


### PR DESCRIPTION
# RELEASE NOTES

## 2026-05-29

* Fix issue #352 - Cluster creation fails when checking OpenShift version
* Add support for `integration of Hetzner DNS into the Hetzner Console`
    * use `hetzner_cloud_api_token` instead of `hetzner_account_api_token` if you already migrated your DNS Zone to Hetzner Console
    * use `hetzner_account_api_token` (as before) if you didn't migrate to Hetzner Console yet
    * [Migration Process](https://docs.hetzner.com/networking/dns/migration-to-hetzner-console/process)
    * [Migration FAQ / Timeline etc.](https://docs.hetzner.com/networking/dns/migration-to-hetzner-console/process)